### PR TITLE
check the unlinkedProviders and unlinkedProviders.providers values before using them in the theme

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -109,7 +109,7 @@
                 </ul>
             </div>
         </#if>
-        <#if realm.password && unlinkedProviders.providers??>
+        <#if realm.password && unlinkedProviders?? && unlinkedProviders.providers??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
                 <hr/>
                 <h4>${msg("ol-unlinked-identity-provider-label")}</h4>


### PR DESCRIPTION
check the unlinkedProviders and unlinkedProviders.providers values before using them.

# What are the relevant tickets?
NA

# Description (What does it do?)
Check all of the java bean values prior to using them in the template.  This PR fixes an issue that occurred when the theme was used for the login form without an attribute provided by a custom form.

# How can this be tested?
This should repair the CI-sandbox realm.

Tested locally by installing and running the theme for login while not using the custom form which provides the unlinkedProviders value.
