### PR TITLE
Fix login URI for unlinked providers on custom username/password form

### DIFF
--- a/ol-keycloak/ol-spi/src/main/java/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/ol-keycloak/ol-spi/src/main/java/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -8,7 +8,9 @@ import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
 import org.keycloak.models.*;
 import org.keycloak.services.resources.LoginActionsService;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,6 +27,11 @@ public class UsernamePasswordForm extends org.keycloak.authentication.authentica
             LoginFormsProvider form = context.form();
             realmIdentityProvidersList.removeAll(identityProvidersLinkedWithUser);
             String requestURI = session.getContext().getUri().getBaseUri().getPath();
+            try {
+                new URL(requestURI);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
             UriBuilder uriBuilder = UriBuilder.fromUri(requestURI);
             ClientModel client = session.getContext().getClient();
             if (client != null) {

--- a/ol-keycloak/ol-spi/src/main/java/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/ol-keycloak/ol-spi/src/main/java/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -1,12 +1,12 @@
 package authentication.authenticators.browser;
 
+import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.forms.login.freemarker.LoginFormsUtil;
 import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
-import org.keycloak.models.IdentityProviderModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.*;
+import org.keycloak.services.resources.LoginActionsService;
 
 import java.net.URI;
 import java.util.List;
@@ -24,8 +24,19 @@ public class UsernamePasswordForm extends org.keycloak.authentication.authentica
             List<IdentityProviderModel> realmIdentityProvidersList = realm.getIdentityProvidersStream().collect(Collectors.toList());
             LoginFormsProvider form = context.form();
             realmIdentityProvidersList.removeAll(identityProvidersLinkedWithUser);
-
-            form.setAttribute("unlinkedProviders", new IdentityProviderBean(realm, session, realmIdentityProvidersList, URI.create("")));
+            String requestURI = session.getContext().getUri().getBaseUri().getPath();
+            UriBuilder uriBuilder = UriBuilder.fromUri(requestURI);
+            ClientModel client = session.getContext().getClient();
+            if (client != null) {
+                uriBuilder.queryParam(Constants.CLIENT_ID, client.getClientId());
+            }
+            if (context.getAuthenticationSession() != null) {
+                uriBuilder.queryParam(Constants.TAB_ID, context.getAuthenticationSession().getTabId());
+                String accessCode = context.generateAccessCode();
+                uriBuilder.queryParam(LoginActionsService.SESSION_CODE, accessCode);
+            }
+            URI baseUriWithCodeAndClientId = uriBuilder.build();
+            form.setAttribute("unlinkedProviders", new IdentityProviderBean(realm, session, realmIdentityProvidersList, baseUriWithCodeAndClientId));
         }
         super.authenticate(context);
     }


### PR DESCRIPTION
# What are the relevant tickets?
NA

# Description (What does it do?)
Fixes an issue that was causing any unlinked providers shown on the Open Learning username/password form to not redirect to the correct location.

The fix is related to building the login URL using additional details from Keycloak such as session code, tab ID, and client ID.

# How can this be tested?
This fix has been testing locally.
