### PR TITLE
Fix login-reset-password form

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-reset-password.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-reset-password.ftl
@@ -4,7 +4,7 @@
         ${msg("emailForgotTitle")}
     <#elseif section = "form">
         <div id="reset-password-subtitle">
-            <h2>${msg("resetPasswordSubtitle)}</h2>
+            <h2>${msg("resetPasswordSubtitle")}</h2>
         </div>
         <form id="kc-reset-password-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">


### PR DESCRIPTION
Missing closing quotation mark.

# What are the relevant tickets?
Thank you to Sar for seeing the error below in the logs.
```
{"application":"keycloak","container_name":"compose-keycloak-1","ec2":{"ami-id":"ami-004bc9af7c1c02c86","availability-zone":"us-east-1d","instance-id":"i-00232407faeb6038b","instance-type":"t3a.medium","local-hostname":"ip-172-16-3-24.ec2.internal","local-ipv4":"172.16.3.24","public-hostname":"ec2-54-221-95-23.compute-1.amazonaws.com","public-ipv4":"54.221.95.23","region":"us-east-1","role-name":["keycloak-instance-role-keycloak-ci-2dc6f7b"],"subnet-id":"subnet-0f9972d95256b3d09","vpc-id":"vpc-07da1a3bca3693f5d"},"host":"ip-172-16-3-24","image":"mitodl/keycloak:v1.0.0-33-g103e5d7","message":"Caused by: freemarker.core.ParseException: Syntax error in template \"login-reset-password.ftl\" in line 9, column 50:","service":"keycloak","source_type":"docker_logs","stream":"stdout"}
```

# Description (What does it do?)
This will fix an issue on the login-reset-password form where I forgot to close a double quotation.

# How can this be tested?
I have tested this locally.

