### PR TITLE
Updated field error styling.

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -44,6 +44,18 @@
         #kc-content {
             align-self: stretch;
 
+            .pf-m-error {
+                color: var(--BrandRed, #A31F34);
+                font-family: Inter;
+                font-size: 14px;
+                font-style: normal;
+                font-weight: 400;
+                line-height: normal;
+                letter-spacing: -0.1px;
+                display: inline-block;
+                margin-top: 10px;
+            }
+
             #kc-reset-password-form {
                 .form-group {
                     margin-bottom: 20px;
@@ -59,18 +71,6 @@
             #kc-register-form {
                 .form-group {
                     margin-bottom: 20px;
-                }
-
-                .pf-m-error {
-                    color: var(--BrandRed, #A31F34);
-                    font-family: Inter;
-                    font-size: 14px;
-                    font-style: normal;
-                    font-weight: 400;
-                    line-height: normal;
-                    letter-spacing: -0.1px;
-                    display: inline-block;
-                    margin-top: 10px;
                 }
 
                 #kc-form-legal-options {

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -61,6 +61,18 @@
                     margin-bottom: 20px;
                 }
 
+                .pf-m-error {
+                    color: var(--BrandRed, #A31F34);
+                    font-family: Inter;
+                    font-size: 14px;
+                    font-style: normal;
+                    font-weight: 400;
+                    line-height: normal;
+                    letter-spacing: -0.1px;
+                    display: inline-block;
+                    margin-top: 10px;
+                }
+
                 #kc-form-legal-options {
                     margin-bottom: 20px;
                 }


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/3207

# Description (What does it do?)
Adds styling to the error messages shown for the fields in the login forms.

# Screenshots (if appropriate):
![Screenshot 2023-12-18 at 1 23 47 PM](https://github.com/mitodl/ol-keycloak/assets/8311573/3452f65b-ae36-4a7c-b183-b241030d2192)

# How can this be tested?
Follow the steps in the README with this branch: https://github.com/mitodl/ol-keycloak?tab=readme-ov-file#steps-to-integrate-with-keycloak.  Navigate to any of the login pages and create an error message for the form field.  Verify that styling added by this PR is displayed.
