### PR TITLE
Added support for reset password prompt on login

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# this file purposely excludes the ignore for plugins/ directory
+.DS_Store

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flake.lock merge=binary linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ol-keycloak/ol-spi/target/*
 ol-keycloak/oltheme/target/*
 .DS_Store
+plugins/

--- a/README.md
+++ b/README.md
@@ -8,8 +8,31 @@ The steps needed to integrate the custom theme and extensions are:
 2. Open a terminal and navigate to this cloned project
 3. In the terminal, from the `ol-keycloak` directory, build the custom java and theme into 2 separate jar files.
 ```
- mvn clean install 
+ mvn clean install
 ```
 4. The output from the `mvn` command above should indicate where the two .jar files were created.
 5. Copy both jar files to the `<keycloak_application_folder>/providers` folder.  This folder should be present when you download the quarkus version of Keycloak.
 6. Start the Keycloak application based on the directions from Keycloak.
+
+
+## Using the Dockerfile
+
+To use the Dockerfile, you must ensure that the directory `plugins/` exists:
+
+```shell
+mkdir -p plugins/
+```
+
+If you need to test locally, you may run `./scripts/build-local.sh` to build the sources and copy the JAR files into `plugins/`.
+
+## Using Nix for local environment
+
+You can use Nix to create a reproducible local dev environment with the tools necessary to build our customizations:
+
+- [Install nix](https://nixos.org/download)
+- [Install nix-direnv](https://github.com/nix-community/nix-direnv?tab=readme-ov-file#installation)
+- Run:
+  ```bash
+  echo "use flake . --impure" > .envrc
+  direnv allow
+  ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,273 @@
+{
+  "nodes": {
+    "devenv": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1708701802,
+        "narHash": "sha256-OvpkuB5Lx8eomwUgUT4s10fzbrDnPCtCsxOlZ63hYFI=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "fa9a708e240c6174f9fc4c6eefbc6a89ce01c350",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678875422,
+        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1704725188,
+        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    devenv.url = "github:cachix/devenv";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.devenv.flakeModule
+      ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        devenv.shells.default = {
+          languages.java = {
+            enable = true;
+            maven.enable = true;
+          };
+        };
+      };
+    };
+}

--- a/ol-keycloak/ol-spi/src/main/java/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
+++ b/ol-keycloak/ol-spi/src/main/java/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
@@ -19,14 +19,16 @@ package forms.login.freemarker;
 import jakarta.ws.rs.core.*;
 import org.keycloak.forms.login.LoginFormsPages;
 import org.keycloak.models.*;
+import org.keycloak.credential.CredentialModel;
 import org.keycloak.theme.Theme;
 import java.util.*;
+import java.util.stream.Stream;
+
 
 import static org.keycloak.forms.login.LoginFormsPages.LOGIN;
 import static org.keycloak.forms.login.LoginFormsPages.LOGIN_PASSWORD;
 
 public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider {
-
     public OlFreeMarkerLoginFormsProvider(KeycloakSession session) {
         super(session);
     }
@@ -35,10 +37,16 @@ public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.fre
         super.createCommonAttributes(theme, locale, messagesBundle,baseUriBuilder,page);
         if (page == LOGIN) {
             String firstName = "";
-            if (context.getUser() != null) {
-                firstName = context.getUser().getFirstName();
+            Boolean hasCredentials = false;
+            UserModel user = context.getUser();
+            if (context.getUser() !=  null) {
+                firstName = user.getFirstName();
+                Stream<CredentialModel> credentials = user.credentialManager().getStoredCredentialsStream();
+                hasCredentials = credentials.count() > 0;
+                
             }
             this.attributes.put("firstName", firstName);
+            this.attributes.put("hasCredentials", hasCredentials);
         }
     }
 }

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -4,71 +4,91 @@
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
         <div id="kc-form">
-          <div id="kc-form-wrapper">
-            <#if realm.password && !social.providers??>
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                    <#if !usernameHidden??>
-                        <div class="${properties.kcFormGroupClass!}">
-                            <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+            <div id="kc-form-wrapper">
+                <#if realm.password && !social.providers??>
+                    <#if hasCredentials>
+                        <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                            <#if !usernameHidden??>
+                                <div class="${properties.kcFormGroupClass!}">
+                                    <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
-                            <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
-                                   aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                            />
+                                    <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
+                                           aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                                    />
 
-                            <#if messagesPerField.existsError('username','password')>
-                                <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
-                                </span>
-                            </#if>
+                                    <#if messagesPerField.existsError('username','password')>
+                                        <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                                ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                        </span>
+                                    </#if>
 
-                        </div>
-                    </#if>
-
-                    <div class="${properties.kcFormGroupClass!}">
-                        <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
-
-                        <div class="${properties.kcInputGroup!}">
-                            <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
-                                   aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                            />
-                        </div>
-
-                        <#if usernameHidden?? && messagesPerField.existsError('username','password')>
-                            <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                    ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
-                            </span>
-                        </#if>
-
-                    </div>
-
-                    <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                        <div id="kc-form-options">
-                            <#if realm.rememberMe && !usernameHidden??>
-                                <div class="checkbox">
-                                    <label>
-                                        <#if login.rememberMe??>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
-                                        <#else>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
-                                        </#if>
-                                    </label>
                                 </div>
                             </#if>
-                            </div>
-                            <div class="${properties.kcFormOptionsWrapperClass!}">
-                                <#if realm.resetPasswordAllowed>
-                                    <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+
+                            <div class="${properties.kcFormGroupClass!}">
+                                <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+
+                                <div class="${properties.kcInputGroup!}">
+                                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
+                                           aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                                    />
+                                </div>
+
+                                <#if usernameHidden?? && messagesPerField.existsError('username','password')>
+                                    <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                            ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                                    </span>
                                 </#if>
+
                             </div>
 
-                      </div>
+                            <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                                <div id="kc-form-options">
+                                    <#if realm.rememberMe && !usernameHidden??>
+                                        <div class="checkbox">
+                                            <label>
+                                                <#if login.rememberMe??>
+                                                    <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                                <#else>
+                                                    <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                                </#if>
+                                            </label>
+                                        </div>
+                                    </#if>
+                                  </div>
+                                  <div class="${properties.kcFormOptionsWrapperClass!}">
+                                      <#if realm.resetPasswordAllowed>
+                                          <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                      </#if>
+                                  </div>
 
-                      <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                          <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                          <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                      </div>
-                </form>
-            </#if>
+                              </div>
+
+                              <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                                  <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+                                  <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                              </div>
+                          </form>
+                      <#elseif realm.resetPasswordAllowed>
+                          <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginResetCredentialsUrl}" method="get">
+                              <div class="${properties.kcFormGroupClass!}">
+                                  <p>
+                                      <b>Password required.</b>
+                                      For security reasons you will need to create a new password for your account.
+                                  </p>
+                              </div>
+                              <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                                  <button tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" id="kc-create-password" type="submit">
+                                      ${msg("createPassword")}
+                                  </button>
+                              </div>
+                          </form>
+                      <#else>
+                          <div class="${properties.kcFormGroupClass!}">
+                              <p>Unable to log you in - no password and password reset is disabled by the administrator.</p>
+                          </div>
+                      </#if>
+                </#if>
             </div>
         </div>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/messages/messages_en.properties
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/messages/messages_en.properties
@@ -36,3 +36,4 @@ emailVerifyInstructionOL4=If you made a typo, no problem, just try creating an a
 emailVerifyInstructionOL5Bold=Still no verification email?
 emailVerifyInstructionOL5=Please contact our MITx Online
 emailVerifySupportLinkTitleOL=Customer Support Center
+createPassword=Create Password

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+
+SCRIPT_DIR=$( dirname -- "${BASH_SOURCE[0]}" )
+
+pushd "$SCRIPT_DIR/.." || exit 1
+
+pushd ol-keycloak || exit 1
+
+mvn clean install
+
+popd || exit 1
+
+cp ol-keycloak/{oltheme,ol-spi}/target/*.jar plugins/
+
+popd || exit 1


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/3473

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds the functional behavior for prompting the user to reset their password if they're attempting to login but don't have a password set or any other credential mechanism (e.g. touchstone).

**Note:** this does not address any look and feel discrepancies vs the designs, it is purely a functional change.

I also added some limited nix flake setup for me to have a workable local dev environment - it doesn't impact functionality here.

### Screenshots (if appropriate):

If you don't have "forgot password" enabled for the realm:
![Screenshot 2024-03-01 at 13-12-22 MIT Open](https://github.com/mitodl/ol-keycloak/assets/28598/31e39827-2a21-4bb7-8a8e-6def65034759)

If you do have it enabled: 
![Screenshot 2024-03-01 at 13-29-28 MIT Open](https://github.com/mitodl/ol-keycloak/assets/28598/ead79567-8b56-42d8-a892-af466c8ce834)


### How can this be tested?
- Create a user with no password in the admin interface
- Verify "Forgot password" is turned off
- Attempt to login as that user and verify that you get an error message that we can't log them in. In practice we shouldn't have this setup this way, but it needed to be handled as it is a potential state and having a helpful error message is better than none.
- Turn on the "forgot password" feature for the realm.
- Try to login again, you should get the prompt to reset your password and it should navigate to the reset password page.
- At this point we've simply navigated the user to the password reset page - anything further isn't effected by this PR (i.e. if password reset works in general, it'll work here too). 