### PR TITLE
Add realm level setting(s) for Open-specific values

### DIFF
--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/admin/ui/OLSettingsAdminUiTab.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/admin/ui/OLSettingsAdminUiTab.java
@@ -1,0 +1,82 @@
+package edu.mit.keycloak.admin.ui;
+
+import org.keycloak.Config;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.services.ui.extend.UiTabProvider;
+import org.keycloak.services.ui.extend.UiTabProviderFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import edu.mit.keycloak.util.OLAttributeKeys;
+/**
+ * Admin UI Tab for providing additional realm-level settings for MIT Open.
+ *
+ * These are things that don't fit well under different scopes like clients.
+ *
+ */
+public class OLSettingsAdminUiTab implements UiTabProvider, UiTabProviderFactory<ComponentModel> {
+    public static String ID = "Open Learning";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Configuration specific to Open Learning";
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void onCreate(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        realm.setAttribute(OLAttributeKeys.HOME_URL, model.get(OLAttributeKeys.HOME_URL));
+    }
+
+    @Override
+    public void onUpdate(KeycloakSession session, RealmModel realm, ComponentModel oldModel, ComponentModel newModel) {
+        newModel.put(OLAttributeKeys.HOME_URL, oldModel.get(OLAttributeKeys.HOME_URL));
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        final ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+        builder.property()
+                .name(OLAttributeKeys.HOME_URL)
+                .label("Canoncial Home URL")
+                .helpText("URL for the homepage of the canonical site for links (e.g. logo)")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add();
+        return builder.build();
+    }
+
+    @Override
+    public String getPath() {
+        return "/:realm/realm-settings/:tab?";
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put("tab", "open");
+        return params;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OLFreeMarkerLoginFormsProviderFactory.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OLFreeMarkerLoginFormsProviderFactory.java
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package forms.login.freemarker;
+package edu.mit.keycloak.forms.login.freemarker;
 
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
 
-public class FreeMarkerLoginFormsProviderFactory extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProviderFactory {
+public class OLFreeMarkerLoginFormsProviderFactory extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProviderFactory {
 
     @Override
     public LoginFormsProvider create(KeycloakSession session) {

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
@@ -14,19 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package forms.login.freemarker;
+package edu.mit.keycloak.forms.login.freemarker;
 
 import jakarta.ws.rs.core.*;
 import org.keycloak.forms.login.LoginFormsPages;
 import org.keycloak.models.*;
-import org.keycloak.credential.CredentialModel;
 import org.keycloak.theme.Theme;
 import java.util.*;
-import java.util.stream.Stream;
 
+
+import edu.mit.keycloak.forms.login.freemarker.models.OLLoginAttemptBean;
+import edu.mit.keycloak.forms.login.freemarker.models.OLSettingsBean;
 
 import static org.keycloak.forms.login.LoginFormsPages.LOGIN;
-import static org.keycloak.forms.login.LoginFormsPages.LOGIN_PASSWORD;
 
 public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider {
     public OlFreeMarkerLoginFormsProvider(KeycloakSession session) {
@@ -34,22 +34,13 @@ public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.fre
     }
 
     protected void createCommonAttributes(Theme theme, Locale locale, Properties messagesBundle, UriBuilder baseUriBuilder, LoginFormsPages page) {
-        super.createCommonAttributes(theme, locale, messagesBundle,baseUriBuilder,page);
+        super.createCommonAttributes(theme, locale, messagesBundle, baseUriBuilder, page);
+
+        attributes.put("olSettings", new OLSettingsBean(realm));
+
         if (page == LOGIN) {
-            String attemptedName = "";
-            Boolean hasCredentials = false;
             UserModel user = context.getUser();
-            if (user != null) {
-                if (user.getFirstName() != null && user.getLastName() != null) {
-                    attemptedName = user.getFirstName().concat(" ").concat(user.getLastName());
-                }
-
-                Stream<CredentialModel> credentials = user.credentialManager().getStoredCredentialsStream();
-                hasCredentials = credentials.count() > 0;
-
-            }
-            this.attributes.put("attemptedName", attemptedName);
-            this.attributes.put("hasCredentials", hasCredentials);
+            attributes.put("loginAttempt", new OLLoginAttemptBean(user));
         }
     }
 }

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
@@ -1,0 +1,31 @@
+package edu.mit.keycloak.forms.login.freemarker.models;
+
+import org.keycloak.models.*;
+import org.keycloak.credential.CredentialModel;
+
+import java.util.stream.Stream;
+
+
+public class OLLoginAttemptBean {
+
+    private UserModel user;
+
+    public OLLoginAttemptBean(UserModel user) {
+        this.user = user;
+    }
+
+    public String getUserFullname() {
+        if (user != null &&
+            user.getFirstName() != null &&
+            user.getLastName() != null
+        ) {
+            user.getFirstName().concat(" ").concat(user.getLastName());
+        }
+        return "";
+    }
+
+    public boolean hasCredentials() {
+        Stream<CredentialModel> credentials = user.credentialManager().getStoredCredentialsStream();
+        return credentials.count() > 0;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLSettingsBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLSettingsBean.java
@@ -1,0 +1,21 @@
+package edu.mit.keycloak.forms.login.freemarker.models;
+
+import java.util.Optional;
+
+import org.keycloak.models.RealmModel;
+
+import edu.mit.keycloak.util.OLAttributeKeys;
+
+
+public class OLSettingsBean {
+
+    private String homeUrl;
+
+    public OLSettingsBean(RealmModel realm) {
+        this.homeUrl = Optional.ofNullable(realm.getAttribute(OLAttributeKeys.HOME_URL)).orElse("#");
+    }
+
+    public String getHomeUrl() {
+      return homeUrl;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/util/OLAttributeKeys.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/util/OLAttributeKeys.java
@@ -1,0 +1,5 @@
+package edu.mit.keycloak.util;
+
+public class OLAttributeKeys {
+  public static final String HOME_URL = "olCanonicalHomeUrl";
+}

--- a/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
+++ b/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
@@ -1,1 +1,1 @@
-forms.login.freemarker.FreeMarkerLoginFormsProviderFactory
+edu.mit.keycloak.forms.login.freemarker.OLFreeMarkerLoginFormsProviderFactory

--- a/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiTabProviderFactory
+++ b/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiTabProviderFactory
@@ -1,0 +1,1 @@
+edu.mit.keycloak.admin.ui.OLSettingsAdminUiTab

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
@@ -1,4 +1,4 @@
-<a href="https://mit.edu" class="logo-link">
+<a href="${olSettings.homeUrl}" class="logo-link">
   <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
  viewBox="0 0 1680 1040" enable-background="new 0 0 1680 1040" xml:space="preserve">
     <path d="M880,880h160V400H880V880z M1120,320h400V160h-400V320z M880,160.00003h160v160H880V160.00003z M640,880h160V160H640V880z

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -81,7 +81,7 @@
       <header class="pf-v5-c-login__main-header">
         <div class="pf-v5-u-mb-2xl">
           <h1 class="pf-v5-c-title pf-m-4xl">
-            <a href="https://mit.edu" class="logo-link pf-v5-u-display-flex pf-v5-u-justify-content-center">
+            <a href="${olSettings.homeUrl}" class="logo-link pf-v5-u-display-flex pf-v5-u-justify-content-center">
               <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
              viewBox="0 0 1680 1040" enable-background="new 0 0 1680 1040" xml:space="preserve">
                 <path d="M880,880h160V400H880V880z M1120,320h400V160h-400V320z M880,160.00003h160v160H880V160.00003z M640,880h160V160H640V880z


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of #47

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a `UITabProvider` which adds an "MIT Open" tab to the realm admin interface as well as exposing the configured data via realm attributes (only 1 for now).

I also did some refactoring of the template provider to organize the properties under beans so they're not all at the top level.

Note: there are several other places that need to use this url too, I'm going to deal with that in a separate PR later. I only did enough here to prove that it works.

### Screenshots (if appropriate):
![Screenshot 2024-04-11 at 15-55-05 Keycloak Administration UI](https://github.com/mitodl/ol-keycloak/assets/28598/a27eaa32-51bc-4b89-b59b-103df057761d)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Go to the admin page and enter the home page url for your open instance (e.g. `http://open.odl.local:8083/`).
- Go to login via keycloak, the logo should now link to the url.
