### PR TITLE
Add realm level setting(s) for Open-specific values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ ol-keycloak/oltheme/target/*
 .DS_Store
 plugins/
 node_modules/
+
+
+# java
+.classpath
+.project
+.settings/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "f12edd9c7be1c20cfa42420fd0e6df71e42b51ea"
-    hooks:
-      - id: prettier
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: debug-statements
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
+        additional_dependencies: ['gibberish-detector']

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -4,7 +4,8 @@
 const config = {
   overrides: [
     {
-      files: ["*.ftl"],
+      // TODO: prettier doesn't handle MJML syntax well
+      // files: ["*.ftl"],
       options: {
         parser: "html",
       },

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -111,16 +115,6 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "93b6a9c0402c7516c5c416ae0bbce27bd2ef9e97",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ]
-  },
-  "generated_at": "2024-03-20T21:23:15Z"
+  "results": {},
+  "generated_at": "2024-04-25T21:40:54Z"
 }

--- a/Dockerfile.hosted
+++ b/Dockerfile.hosted
@@ -1,4 +1,4 @@
-# Build with something like: 
+# Build with something like:
 #  docker build -f ./Dockerfile.hosted --build-arg $(cat .keycloak_upstream_tag) --platform=linux/amd64 .
 FROM quay.io/keycloak/keycloak:24.0@sha256:b8a3f00fc433f2999bc304b73df331e2005037e8f5673f644f9c0eacd5fbe048
 
@@ -6,7 +6,7 @@ COPY ol-keycloak/oltheme/src/main/resources/theme/ /opt/keycloak/themes/
 #COPY ol-keycloak/ol-spi/ /opt/keycloak/providers/
 COPY plugins/*.jar /opt/keycloak/providers/
 RUN /opt/keycloak/bin/kc.sh build
-# All env vars for hosted instances should be specified in 
+# All env vars for hosted instances should be specified in
 # .env in the ol-infrastructure repo.
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/ol-keycloak/ol-spi/pom.xml
+++ b/ol-keycloak/ol-spi/pom.xml
@@ -32,5 +32,5 @@
             <version>24.0.2</version>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/admin/ui/OLSettingsAdminUiTab.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/admin/ui/OLSettingsAdminUiTab.java
@@ -1,0 +1,82 @@
+package edu.mit.keycloak.admin.ui;
+
+import org.keycloak.Config;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.services.ui.extend.UiTabProvider;
+import org.keycloak.services.ui.extend.UiTabProviderFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import edu.mit.keycloak.util.OLAttributeKeys;
+/**
+ * Admin UI Tab for providing additional realm-level settings for MIT Open.
+ *
+ * These are things that don't fit well under different scopes like clients.
+ *
+ */
+public class OLSettingsAdminUiTab implements UiTabProvider, UiTabProviderFactory<ComponentModel> {
+    public static String ID = "Open Learning";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Configuration specific to Open Learning";
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void onCreate(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        realm.setAttribute(OLAttributeKeys.HOME_URL, model.get(OLAttributeKeys.HOME_URL));
+    }
+
+    @Override
+    public void onUpdate(KeycloakSession session, RealmModel realm, ComponentModel oldModel, ComponentModel newModel) {
+        newModel.put(OLAttributeKeys.HOME_URL, oldModel.get(OLAttributeKeys.HOME_URL));
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        final ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+        builder.property()
+                .name(OLAttributeKeys.HOME_URL)
+                .label("Canoncial Home URL")
+                .helpText("URL for the homepage of the canonical site for links (e.g. logo)")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add();
+        return builder.build();
+    }
+
+    @Override
+    public String getPath() {
+        return "/:realm/realm-settings/:tab?";
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put("tab", "open");
+        return params;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OLFreeMarkerLoginFormsProviderFactory.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OLFreeMarkerLoginFormsProviderFactory.java
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package forms.login.freemarker;
+package edu.mit.keycloak.forms.login.freemarker;
 
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
 
-public class FreeMarkerLoginFormsProviderFactory extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProviderFactory {
+public class OLFreeMarkerLoginFormsProviderFactory extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProviderFactory {
 
     @Override
     public LoginFormsProvider create(KeycloakSession session) {

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
@@ -14,19 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package forms.login.freemarker;
+package edu.mit.keycloak.forms.login.freemarker;
 
 import jakarta.ws.rs.core.*;
 import org.keycloak.forms.login.LoginFormsPages;
 import org.keycloak.models.*;
-import org.keycloak.credential.CredentialModel;
 import org.keycloak.theme.Theme;
 import java.util.*;
-import java.util.stream.Stream;
 
+
+import edu.mit.keycloak.forms.login.freemarker.models.OLLoginAttemptBean;
+import edu.mit.keycloak.forms.login.freemarker.models.OLSettingsBean;
 
 import static org.keycloak.forms.login.LoginFormsPages.LOGIN;
-import static org.keycloak.forms.login.LoginFormsPages.LOGIN_PASSWORD;
 
 public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider {
     public OlFreeMarkerLoginFormsProvider(KeycloakSession session) {
@@ -34,22 +34,13 @@ public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.fre
     }
 
     protected void createCommonAttributes(Theme theme, Locale locale, Properties messagesBundle, UriBuilder baseUriBuilder, LoginFormsPages page) {
-        super.createCommonAttributes(theme, locale, messagesBundle,baseUriBuilder,page);
-        if (page == LOGIN) {
-            String attemptedName = "";
-            Boolean hasCredentials = false;
+        super.createCommonAttributes(theme, locale, messagesBundle, baseUriBuilder, page);
+
+        attributes.put("olSettings", new OLSettingsBean(realm));
+
+        if (page.equals(LOGIN)) {
             UserModel user = context.getUser();
-            if (user != null) {
-                if (user.getFirstName() != null && user.getLastName() != null) {
-                    attemptedName = user.getFirstName().concat(" ").concat(user.getLastName());
-                }
-
-                Stream<CredentialModel> credentials = user.credentialManager().getStoredCredentialsStream();
-                hasCredentials = credentials.count() > 0;
-
-            }
-            this.attributes.put("attemptedName", attemptedName);
-            this.attributes.put("hasCredentials", hasCredentials);
+            attributes.put("loginAttempt", new OLLoginAttemptBean(user));
         }
     }
 }

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
@@ -1,0 +1,43 @@
+package edu.mit.keycloak.forms.login.freemarker.models;
+
+import org.keycloak.models.*;
+import org.keycloak.models.credential.PasswordCredentialModel;
+
+
+public class OLLoginAttemptBean {
+
+    private String userFullname;
+    private boolean needsPassword;
+    private boolean hasSocialProviderAuth;
+
+    public OLLoginAttemptBean(UserModel user) {
+        this.userFullname = "";
+        this.needsPassword = true;
+        this.hasSocialProviderAuth = false;
+        if (user != null) {
+            if (user.getFirstName() != null && user.getLastName() != null) {
+                this.userFullname = user.getFirstName().concat(" ").concat(user.getLastName());
+            }
+
+            user.credentialManager().getStoredCredentialsStream().forEach(credential -> {
+                if (credential.getType().equals(PasswordCredentialModel.TYPE)) {
+                    this.needsPassword = false;
+                } else {
+                    this.hasSocialProviderAuth = true;
+                }
+            });
+        }
+    }
+
+    public String getUserFullname() {
+        return userFullname;
+    }
+
+    public boolean getNeedsPassword() {
+        return needsPassword;
+    }
+
+    public boolean getHasSocialProviderAuth() {
+        return hasSocialProviderAuth;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLSettingsBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLSettingsBean.java
@@ -1,0 +1,21 @@
+package edu.mit.keycloak.forms.login.freemarker.models;
+
+import java.util.Optional;
+
+import org.keycloak.models.RealmModel;
+
+import edu.mit.keycloak.util.OLAttributeKeys;
+
+
+public class OLSettingsBean {
+
+    private String homeUrl;
+
+    public OLSettingsBean(RealmModel realm) {
+        this.homeUrl = Optional.ofNullable(realm.getAttribute(OLAttributeKeys.HOME_URL)).orElse("#");
+    }
+
+    public String getHomeUrl() {
+      return homeUrl;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/util/OLAttributeKeys.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/util/OLAttributeKeys.java
@@ -1,0 +1,5 @@
+package edu.mit.keycloak.util;
+
+public class OLAttributeKeys {
+  public static final String HOME_URL = "olCanonicalHomeUrl";
+}

--- a/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
+++ b/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.forms.login.LoginFormsProviderFactory
@@ -1,1 +1,1 @@
-forms.login.freemarker.FreeMarkerLoginFormsProviderFactory
+edu.mit.keycloak.forms.login.freemarker.OLFreeMarkerLoginFormsProviderFactory

--- a/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiTabProviderFactory
+++ b/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiTabProviderFactory
@@ -1,0 +1,1 @@
+edu.mit.keycloak.admin.ui.OLSettingsAdminUiTab

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
@@ -1,4 +1,4 @@
-<a href="https://mit.edu" class="logo-link">
+<a href="${olSettings.homeUrl!"#"}" class="logo-link">
   <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
  viewBox="0 0 1680 1040" enable-background="new 0 0 1680 1040" xml:space="preserve">
     <path d="M880,880h160V400H880V880z M1120,320h400V160h-400V320z M880,160.00003h160v160H880V160.00003z M640,880h160V160H640V880z

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -1,8 +1,8 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
-        <#if (attemptedName!"")?has_content>
-            ${msg("loginGreeting")} ${attemptedName}!
+        <#if loginAttempt.userFullname?has_content>
+            ${msg("loginGreeting")} ${loginAttempt.userFullname}!
         <#else>
             ${msg("loginAccountTitle")}
         </#if>
@@ -10,7 +10,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password && !social.providers??>
-                <#if hasCredentials>
+                <#if !loginAttempt.needsPassword>
                     <form id="kc-form-login" class="${properties.kcFormClass!} onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                         <#if !usernameHidden??>
                             <div class="${properties.kcFormGroupClass!}">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -81,7 +81,7 @@
       <header class="pf-v5-c-login__main-header">
         <div class="pf-v5-u-mb-2xl">
           <h1 class="pf-v5-c-title pf-m-4xl">
-            <a href="https://mit.edu" class="logo-link pf-v5-u-display-flex pf-v5-u-justify-content-center">
+            <a href="${(olSettings.homeUrl)!"#"}" class="logo-link pf-v5-u-display-flex pf-v5-u-justify-content-center">
               <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
              viewBox="0 0 1680 1040" enable-background="new 0 0 1680 1040" xml:space="preserve">
                 <path d="M880,880h160V400H880V880z M1120,320h400V160h-400V320z M880,160.00003h160v160H880V160.00003z M640,880h160V160H640V880z


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of #47 

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR includes:
- The [original work](https://github.com/mitodl/ol-keycloak/pull/52) I merged and then reverted
- Bug fixes for exceptions happening:
  - If your realm didn't have the canonical home url set, this caused a template error
  - When _that_ error happened, it cascaded into another error because the error page itself tries to use `template.ftl` and `olSettings` isn't defined for that. I updated the template to fail over to `#` for now in that situation because I haven't figured out how to inject values into the error page yet.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Similar testing of login, register, password reset, etc as before, although I largely haven't changed this code.
- To test that the error page is working again, you can put in `login.ftl` a variable interpolation for one that doesn't exist (e.g. `${abc.def.ghi}`), this should be enough to trigger the error page on that page since trying to throw an error explicitly from java doesn't work because of the method typings.
