### PR TITLE
Update emails to align to new designs

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
@@ -108,7 +108,7 @@
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+            <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
               <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -157,7 +157,7 @@
                                 </td>
                               </tr>
                               <tr>
-                                <td align="left" style="font-size:0px;padding:18px 16px;word-break:break-word;">
+                                <td align="left" style="font-size:0px;padding:12px 25px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                                     <tbody>
                                       <tr>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
@@ -66,16 +66,6 @@
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
-      .mj-column-px-150 {
-        width: 150px !important;
-        max-width: 150px;
-      }
-
-      .mj-column-px-450 {
-        width: 450px !important;
-        max-width: 450px;
-      }
-
       .mj-column-per-100 {
         width: 100% !important;
         max-width: 100%;
@@ -84,16 +74,6 @@
 
   </style>
   <style media="screen and (min-width:480px)">
-    .moz-text-html .mj-column-px-150 {
-      width: 150px !important;
-      max-width: 150px;
-    }
-
-    .moz-text-html .mj-column-px-450 {
-      width: 450px !important;
-      max-width: 450px;
-    }
-
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
@@ -113,6 +93,14 @@
 
   </style>
   <style type="text/css">
+    h1 {
+      color: #212326;
+    }
+
+    .email-body {
+      padding-top: 20px;
+    }
+
     .logo-text a,
     .logo-textd .logo-text a,
     :visited,
@@ -125,129 +113,138 @@
   </style>
 </head>
 
-<body style="word-spacing:normal;">
-  <div style="" lang="und" dir="auto">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+<body style="word-spacing:normal;background-color:#F3F4F8;">
+  <div class="email-body" style="background-color:#F3F4F8;" lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:150px;" ><![endif]-->
-              <div class="mj-column-px-150 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                          <tbody>
-                            <tr>
-                              <td style="width:150px;">
-                                <a href="https://mit.edu" target="_blank">
-                                  <img alt="" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="150" height="auto" />
-                                </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
+                      <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                    <tbody>
+                                      <tr>
+                                        <td style="width:64px;">
+                                          <a href="https://mit.edu" target="_blank">
+                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <h1 class="logo-text">
+                                      <a href="${msg(" homeUrl")}">Open</a>
+                                    </h1>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td><td class="" style="vertical-align:middle;width:450px;" ><![endif]-->
-              <div class="mj-column-px-450 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <h1 class="logo-text">
-                            <a href="${msg(" homeUrl")}">Open</a>
-                          </h1>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <h1>Verify Your Email</h1>
+                                    <p> Thank you for creating an account with ${realmName}. Please complete the account verification process by verifying your email. </p>
+                                    <p>To verify your email, please click this link:</p>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:18px 16px;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#A31F34" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#A31F34;" valign="middle">
+                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:Inter, Arial;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Verify Your Email </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <p>Welcome and thanks!<br /><b>${realmName} Team</b></p>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <h1>Verify Your Email</h1>
-                          <p> Thank you for creating an account with ${realmName}. Please complete the account verification process by verifying your email. </p>
-                          <p>To verify your email, please click this link:</p>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
+                                  <p style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:100%;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:560px;" role="presentation" width="560px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:12px;line-height:1;text-align:center;color:#212326;"><b>MIT</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#283343" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#283343;" valign="middle">
-                                <a href="${link}" style="display:inline-block;background:#283343;color:#ffffff;font-family:Inter, Arial;font-size:13px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:5px;" target="_blank"> Verify Your Email </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <p> If the button doesn't work, copy and paste this link into your web browser: </p>
-                          <p>${link}</p>
-                          <p>Welcome and thanks!<br />${realmName} Team</p>
-                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-                  <tbody>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">MIT, 77 Massachusetts Ave, Cambridge, MA 02139 <br /> ©${.now?string('yyyy')} Massachusetts Institute of Technology, All Rights Reserved. <br />
-                          <a href="#">${msg("termsOfService")}</a> ${msg("and")} <a href="#">${msg("privacyPolicy")}</a>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
             </td>
           </tr>
         </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
@@ -81,18 +81,6 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:479px) {
-      table.mj-full-width-mobile {
-        width: 100% !important;
-      }
-
-      td.mj-full-width-mobile {
-        width: auto !important;
-      }
-    }
-
-  </style>
-  <style type="text/css">
     h1 {
       color: #212326;
     }
@@ -127,29 +115,14 @@
                   <tbody>
                     <tr>
                       <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                                    <tbody>
-                                      <tr>
-                                        <td style="width:64px;">
-                                          <a href="https://mit.edu" target="_blank">
-                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
-                                          </a>
-                                        </td>
-                                      </tr>
-                                    </tbody>
-                                  </table>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                                    <h1 class="logo-text">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:center;color:#000000;"><img src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" href="https://mit.edu" width="64px" height="40px" alt="MIT" style="vertical-align: middle;" />
+                                    <h1 class="logo-text" style="vertical-align: middle; display: inline;">
                                       <a href="${msg(" homeUrl")}">Open</a>
                                     </h1>
                                   </div>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
@@ -66,16 +66,6 @@
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
-      .mj-column-px-150 {
-        width: 150px !important;
-        max-width: 150px;
-      }
-
-      .mj-column-px-450 {
-        width: 450px !important;
-        max-width: 450px;
-      }
-
       .mj-column-per-100 {
         width: 100% !important;
         max-width: 100%;
@@ -84,16 +74,6 @@
 
   </style>
   <style media="screen and (min-width:480px)">
-    .moz-text-html .mj-column-px-150 {
-      width: 150px !important;
-      max-width: 150px;
-    }
-
-    .moz-text-html .mj-column-px-450 {
-      width: 450px !important;
-      max-width: 450px;
-    }
-
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
@@ -113,6 +93,14 @@
 
   </style>
   <style type="text/css">
+    h1 {
+      color: #212326;
+    }
+
+    .email-body {
+      padding-top: 20px;
+    }
+
     .logo-text a,
     .logo-textd .logo-text a,
     :visited,
@@ -125,128 +113,139 @@
   </style>
 </head>
 
-<body style="word-spacing:normal;">
-  <div style="" lang="und" dir="auto">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+<body style="word-spacing:normal;background-color:#F3F4F8;">
+  <div class="email-body" style="background-color:#F3F4F8;" lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:150px;" ><![endif]-->
-              <div class="mj-column-px-150 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                          <tbody>
-                            <tr>
-                              <td style="width:150px;">
-                                <a href="https://mit.edu" target="_blank">
-                                  <img alt="" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="150" height="auto" />
-                                </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
+                      <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                    <tbody>
+                                      <tr>
+                                        <td style="width:64px;">
+                                          <a href="https://mit.edu" target="_blank">
+                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <h1 class="logo-text">
+                                      <a href="${msg(" homeUrl")}">Open</a>
+                                    </h1>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td><td class="" style="vertical-align:middle;width:450px;" ><![endif]-->
-              <div class="mj-column-px-450 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <h1 class="logo-text">
-                            <a href="${msg(" homeUrl")}">Open</a>
-                          </h1>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <h1>Reset Your Password</h1>
+                                    <p> You're receiving this because you requested a password reset for your user account at ${realmName}. </p>
+                                    <p>Please go to the following page and choose a new password:</p>
+                                  </div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#283343" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#283343;" valign="middle">
+                                          <a href="${link}" style="display:inline-block;background:#283343;color:#ffffff;font-family:Inter, Arial;font-size:13px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:5px;" target="_blank"> Reset Password </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <p> If the button doesn't work, copy and paste this link into your web browser: </p>
+                                    <p>${link}</p>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <h1>Reset Your Password</h1>
-                          <p> You're receiving this because you requested a password reset for your user account at ${realmName}. </p>
-                          <p>Please go to the following page and choose a new password:</p>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
+                                  <p style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:100%;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:560px;" role="presentation" width="560px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:12px;line-height:1;text-align:center;color:#212326;"><b>MIT</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                          <tbody>
-                            <tr>
-                              <td align="center" bgcolor="#283343" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#283343;" valign="middle">
-                                <a href="${link}" style="display:inline-block;background:#283343;color:#ffffff;font-family:Inter, Arial;font-size:13px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:5px;" target="_blank"> Reset Password </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <p> If the button doesn't work, copy and paste this link into your web browser: </p>
-                          <p>${link}</p>
-                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-                  <tbody>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">MIT, 77 Massachusetts Ave, Cambridge, MA 02139 <br /> ©${.now?string('yyyy')} Massachusetts Institute of Technology, All Rights Reserved. <br />
-                          <a href="#">${msg("termsOfService")}</a> ${msg("and")} <a href="#">${msg("privacyPolicy")}</a>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
             </td>
           </tr>
         </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
@@ -108,7 +108,7 @@
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+            <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
               <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -157,12 +157,12 @@
                                 </td>
                               </tr>
                               <tr>
-                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                <td align="left" style="font-size:0px;padding:12px 25px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
                                     <tbody>
                                       <tr>
-                                        <td align="center" bgcolor="#283343" role="presentation" style="border:none;border-radius:5px;cursor:auto;mso-padding-alt:10px 25px;background:#283343;" valign="middle">
-                                          <a href="${link}" style="display:inline-block;background:#283343;color:#ffffff;font-family:Inter, Arial;font-size:13px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:5px;" target="_blank"> Reset Password </a>
+                                        <td align="center" bgcolor="#A31F34" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#A31F34;" valign="middle">
+                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:Inter, Arial;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Reset Password </a>
                                         </td>
                                       </tr>
                                     </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
@@ -81,18 +81,6 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:479px) {
-      table.mj-full-width-mobile {
-        width: 100% !important;
-      }
-
-      td.mj-full-width-mobile {
-        width: auto !important;
-      }
-    }
-
-  </style>
-  <style type="text/css">
     h1 {
       color: #212326;
     }
@@ -127,29 +115,14 @@
                   <tbody>
                     <tr>
                       <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                                    <tbody>
-                                      <tr>
-                                        <td style="width:64px;">
-                                          <a href="https://mit.edu" target="_blank">
-                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
-                                          </a>
-                                        </td>
-                                      </tr>
-                                    </tbody>
-                                  </table>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                                    <h1 class="logo-text">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:center;color:#000000;"><img src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" href="https://mit.edu" width="64px" height="40px" alt="MIT" style="vertical-align: middle;" />
+                                    <h1 class="logo-text" style="vertical-align: middle; display: inline;">
                                       <a href="${msg(" homeUrl")}">Open</a>
                                     </h1>
                                   </div>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
@@ -82,18 +82,6 @@
 
   </style>
   <style type="text/css">
-    @media only screen and (max-width:479px) {
-      table.mj-full-width-mobile {
-        width: 100% !important;
-      }
-
-      td.mj-full-width-mobile {
-        width: auto !important;
-      }
-    }
-
-  </style>
-  <style type="text/css">
     h1 {
       color: #212326;
     }
@@ -128,29 +116,14 @@
                   <tbody>
                     <tr>
                       <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                                    <tbody>
-                                      <tr>
-                                        <td style="width:64px;">
-                                          <a href="https://mit.edu" target="_blank">
-                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
-                                          </a>
-                                        </td>
-                                      </tr>
-                                    </tbody>
-                                  </table>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                                    <h1 class="logo-text">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:center;color:#000000;"><img src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" href="https://mit.edu" width="64px" height="40px" alt="MIT" style="vertical-align: middle;" />
+                                    <h1 class="logo-text" style="vertical-align: middle; display: inline;">
                                       <a href="${msg(" homeUrl")}">Open</a>
                                     </h1>
                                   </div>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
@@ -109,7 +109,7 @@
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+            <td style="direction:ltr;font-size:0px;padding:0;text-align:center;">
               <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:600px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
@@ -67,16 +67,6 @@
   <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
-      .mj-column-px-150 {
-        width: 150px !important;
-        max-width: 150px;
-      }
-
-      .mj-column-px-450 {
-        width: 450px !important;
-        max-width: 450px;
-      }
-
       .mj-column-per-100 {
         width: 100% !important;
         max-width: 100%;
@@ -85,16 +75,6 @@
 
   </style>
   <style media="screen and (min-width:480px)">
-    .moz-text-html .mj-column-px-150 {
-      width: 150px !important;
-      max-width: 150px;
-    }
-
-    .moz-text-html .mj-column-px-450 {
-      width: 450px !important;
-      max-width: 450px;
-    }
-
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
@@ -114,6 +94,14 @@
 
   </style>
   <style type="text/css">
+    h1 {
+      color: #212326;
+    }
+
+    .email-body {
+      padding-top: 20px;
+    }
+
     .logo-text a,
     .logo-textd .logo-text a,
     :visited,
@@ -126,105 +114,116 @@
   </style>
 </head>
 
-<body style="word-spacing:normal;">
-  <div style="" lang="und" dir="auto">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+<body style="word-spacing:normal;background-color:#F3F4F8;">
+  <div class="email-body" style="background-color:#F3F4F8;" lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:150px;" ><![endif]-->
-              <div class="mj-column-px-150 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
-                          <tbody>
-                            <tr>
-                              <td style="width:150px;">
-                                <a href="https://mit.edu" target="_blank">
-                                  <img alt="" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="150" height="auto" />
-                                </a>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <!--[if mso | IE]></td><td class="" style="vertical-align:middle;width:450px;" ><![endif]-->
-              <div class="mj-column-px-450 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
-                  <tbody>
-                    <tr>
-                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <h1 class="logo-text">
-                            <a href="${msg(" homeUrl")}">Open</a>
-                          </h1>
+                      <td style="border-bottom:1px solid #DDE1E6;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:middle;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:middle;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:middle;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                    <tbody>
+                                      <tr>
+                                        <td style="width:64px;">
+                                          <a href="https://mit.edu" target="_blank">
+                                            <img alt="MIT" src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png" style="border:0;display:block;outline:none;text-decoration:none;height:40px;width:100%;font-size:13px;" width="64" height="40" />
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <h1 class="logo-text">
+                                      <a href="${msg(" homeUrl")}">Open</a>
+                                    </h1>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
-                          <#nested>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">
+                                    <#nested>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
-              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:600px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter, Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">MIT, 77 Massachusetts Ave, Cambridge, MA 02139 <br /> ©${.now?string('yyyy')} Massachusetts Institute of Technology, All Rights Reserved. <br />
-                          <a href="#">${msg("termsOfService")}</a> ${msg("and")} <a href="#">${msg("privacyPolicy")}</a>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:20px;word-break:break-word;">
+                                  <p style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:100%;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #DDE1E6;font-size:1px;margin:0px auto;width:560px;" role="presentation" width="560px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:Inter, Arial;font-size:12px;line-height:1;text-align:center;color:#212326;"><b>MIT</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
                         </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
                       </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
             </td>
           </tr>
         </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/email-verification.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/email-verification.mjml
@@ -1,7 +1,7 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
   <mj-body background-color="#F3F4F8" css-class="email-body">
-    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px" padding="0">
       <mj-include path="./includes/header.mjml" />
 
       <mj-section background-color="#FFFFFF">
@@ -15,7 +15,7 @@
             <p>To verify your email, please click this link:</p>
           </mj-text>
           <mj-button href="${link}" border-radius="4px" background-color="#A31F34" align="left" font-weight="bold"
-            font-size="14px" color="#FFFFFF" padding="18px 16px">
+            font-size="14px" color="#FFFFFF" padding="12px 25px">
             Verify Your Email
           </mj-button>
           <mj-text>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/email-verification.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/email-verification.mjml
@@ -1,38 +1,30 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
-  <mj-body>
-    <mj-include path="./includes/header.mjml" />
+  <mj-body background-color="#F3F4F8" css-class="email-body">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+      <mj-include path="./includes/header.mjml" />
 
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h1>Verify Your Email</h1>
-          <p>
-            Thank you for creating an account with ${realmName}. Please complete
-            the account verification process by verifying your email.
-          </p>
-          <p>To verify your email, please click this link:</p>
-        </mj-text>
-        <mj-button
-          href="${link}"
-          border-radius="5px"
-          background-color="#283343"
-          align="left"
-          font-weight="bold"
-        >
-          Verify Your Email
-        </mj-button>
-        <mj-text>
-          <p>
-            If the button doesn't work, copy and paste this link into your web
-            browser:
-          </p>
-          <p>${link}</p>
-          <p>Welcome and thanks!<br />${realmName} Team</p>
-        </mj-text>
-      </mj-column>
-    </mj-section>
+      <mj-section background-color="#FFFFFF">
+        <mj-column>
+          <mj-text>
+            <h1>Verify Your Email</h1>
+            <p>
+              Thank you for creating an account with ${realmName}. Please complete
+              the account verification process by verifying your email.
+            </p>
+            <p>To verify your email, please click this link:</p>
+          </mj-text>
+          <mj-button href="${link}" border-radius="4px" background-color="#A31F34" align="left" font-weight="bold"
+            font-size="14px" color="#FFFFFF" padding="18px 16px">
+            Verify Your Email
+          </mj-button>
+          <mj-text>
+            <p>Welcome and thanks!<br /><b>${realmName} Team</b></p>
+          </mj-text>
+        </mj-column>
+      </mj-section>
 
-    <mj-include path="./includes/footer.mjml" />
+      <mj-include path="./includes/footer.mjml" />
+    </mj-wrapper>
   </mj-body>
 </mjml>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/_head.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/_head.mjml
@@ -7,6 +7,8 @@
     <mj-all font-family="Inter, Arial" font-size="13px" />
   </mj-attributes>
   <mj-style>
+    h1 { color: #212326; }
+    .email-body { padding-top: 20px; }
     .logo-text a, .logo-textd .logo-text a, :visited, .logo-text a:hover,
     .logo-text a:active { text-decoration: none; color: #261918; }
   </mj-style>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/footer.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/footer.mjml
@@ -1,13 +1,17 @@
 <mj-section>
   <mj-column>
-    <mj-text font-size="13px">
-      MIT, 77 Massachusetts Ave, Cambridge, MA 02139
-      <br />
-      ©${.now?string('yyyy')} Massachusetts Institute of Technology, All Rights
-      Reserved.
-      <br />
-      <a href="#">${msg("termsOfService")}</a> ${msg("and")}
-      <a href="#">${msg("privacyPolicy")}</a>
+    <mj-divider
+      border-width="1px"
+      border-style="solid"
+      border-color="#DDE1E6"
+      padding="20px"
+    />
+    <mj-text
+      font-size="12px"
+      align="center"
+      color="#212326"
+    >
+      <b>MIT</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA
     </mj-text>
   </mj-column>
 </mj-section>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/header.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/header.mjml
@@ -1,17 +1,15 @@
 <mj-section border-bottom="1px solid #DDE1E6">
-  <mj-column
-    vertical-align="middle"
-  >
-    <mj-image
-      src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png"
-      href="https://mit.edu"
-      padding="0"
-      width="64px"
-      height="40px"
-      alt="MIT"
-    />
-    <mj-text padding="0">
-      <h1 class="logo-text">
+  <mj-column>
+    <mj-text padding="0" align="center">
+      <img
+        src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png"
+        href="https://mit.edu"
+        width="64px"
+        height="40px"
+        alt="MIT"
+        style="vertical-align: middle;"
+      />
+      <h1 class="logo-text" style="vertical-align: middle; display: inline;">
         <a href="${msg("homeUrl")}">Open</a>
       </h1>
     </mj-text>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/header.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/header.mjml
@@ -1,19 +1,15 @@
-<mj-section>
+<mj-section border-bottom="1px solid #DDE1E6">
   <mj-column
     vertical-align="middle"
-    width="150px"
   >
     <mj-image
       src="${url.resourcesUrl}/img/mit_logo_std_rgb_black.png"
       href="https://mit.edu"
       padding="0"
-      alt=""
+      width="64px"
+      height="40px"
+      alt="MIT"
     />
-  </mj-column>
-  <mj-column
-    vertical-align="middle"
-    width="450px"
-  >
     <mj-text padding="0">
       <h1 class="logo-text">
         <a href="${msg("homeUrl")}">Open</a>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
@@ -1,7 +1,7 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
   <mj-body background-color="#F3F4F8" css-class="email-body">
-    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px" padding="0">
       <mj-include path="./includes/header.mjml" />
 
       <mj-section>
@@ -15,7 +15,7 @@
             <p>Please go to the following page and choose a new password:</p>
           </mj-text>
           <mj-button href="${link}" border-radius="4px" background-color="#A31F34" align="left" font-weight="bold"
-            font-size="14px" color="#FFFFFF" padding="18px 16px">
+            font-size="14px" color="#FFFFFF" padding="12px 25px">
             Reset Password
           </mj-button>
           <mj-text>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
@@ -1,37 +1,33 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
-  <mj-body>
-    <mj-include path="./includes/header.mjml" />
+  <mj-body background-color="#F3F4F8" css-class="email-body">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+      <mj-include path="./includes/header.mjml" />
 
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h1>Reset Your Password</h1>
-          <p>
-            You're receiving this because you requested a password reset for
-            your user account at ${realmName}.
-          </p>
-          <p>Please go to the following page and choose a new password:</p>
-        </mj-text>
-        <mj-button
-          href="${link}"
-          border-radius="5px"
-          background-color="#283343"
-          align="left"
-          font-weight="bold"
-        >
-          Reset Password
-        </mj-button>
-        <mj-text>
-          <p>
-            If the button doesn't work, copy and paste this link into your web
-            browser:
-          </p>
-          <p>${link}</p>
-        </mj-text>
-      </mj-column>
-    </mj-section>
+      <mj-section>
+        <mj-column>
+          <mj-text>
+            <h1>Reset Your Password</h1>
+            <p>
+              You're receiving this because you requested a password reset for
+              your user account at ${realmName}.
+            </p>
+            <p>Please go to the following page and choose a new password:</p>
+          </mj-text>
+          <mj-button href="${link}" border-radius="5px" background-color="#283343" align="left" font-weight="bold">
+            Reset Password
+          </mj-button>
+          <mj-text>
+            <p>
+              If the button doesn't work, copy and paste this link into your web
+              browser:
+            </p>
+            <p>${link}</p>
+          </mj-text>
+        </mj-column>
+      </mj-section>
 
-    <mj-include path="./includes/footer.mjml" />
+      <mj-include path="./includes/footer.mjml" />
+    </mj-wrapper>
   </mj-body>
 </mjml>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/password-reset.mjml
@@ -14,7 +14,8 @@
             </p>
             <p>Please go to the following page and choose a new password:</p>
           </mj-text>
-          <mj-button href="${link}" border-radius="5px" background-color="#283343" align="left" font-weight="bold">
+          <mj-button href="${link}" border-radius="4px" background-color="#A31F34" align="left" font-weight="bold"
+            font-size="14px" color="#FFFFFF" padding="18px 16px">
             Reset Password
           </mj-button>
           <mj-text>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/template.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/template.mjml
@@ -1,7 +1,7 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
   <mj-body background-color="#F3F4F8" css-class="email-body">
-    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px" padding="0">
       <mj-include path="./includes/header.mjml" />
 
       <mj-section>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/template.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/template.mjml
@@ -1,14 +1,18 @@
 <mjml>
   <mj-include path="./includes/_head.mjml" />
-  <mj-body>
-    <mj-include path="./includes/header.mjml" />
+  <mj-body background-color="#F3F4F8" css-class="email-body">
+    <mj-wrapper background-color="#FFFFFF" border-radius="8px">
+      <mj-include path="./includes/header.mjml" />
 
-    <mj-section>
-      <mj-column>
-        <mj-text font-size="13px"><#nested></mj-text>
-      </mj-column>
-    </mj-section>
+      <mj-section>
+        <mj-column>
+          <mj-text font-size="13px">
+            <#nested>
+          </mj-text>
+        </mj-column>
+      </mj-section>
 
-    <mj-include path="./includes/footer.mjml" />
+      <mj-include path="./includes/footer.mjml" />
+    </mj-wrapper>
   </mj-body>
 </mjml>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/4932

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Updates the base template
- Primarily updates the email verification template
- Some light updates to the password reset email. Mainly the button color change, just to have that match the other email. Did not touch the actual content of that email as it's out of scope.

Note: the designs include a box-shadow on the button because that's our standard design, but box-shadow is widely unsupported in email clients so I left that out.
