### PR TITLE
Adjustments to theme to match latest UX

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/email-verification.ftl
@@ -58,9 +58,9 @@
     </style>
     <![endif]-->
   <!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" type="text/css">
+  <link href="https://use.typekit.net/lbk1xay.css" rel="stylesheet" type="text/css">
   <style type="text/css">
-    @import url(https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap);
+    @import url(https://use.typekit.net/lbk1xay.css);
 
   </style>
   <!--<![endif]-->
@@ -99,6 +99,8 @@
     }
 
   </style>
+  <!-- Font files for Adobe Neue Haas Grotesk.
+    WARNING: This is linked to chudzick@mit.edu's Adobe account. -->
 </head>
 
 <body style="word-spacing:normal;background-color:#F3F4F8;">
@@ -121,7 +123,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
                                       <img src="${url.resourcesUrl}/img/MITlearn.png" height="29" width="103" alt="MIT Learn" />
                                     </a></div>
                                 </td>
@@ -147,7 +149,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:left;color:#000000;">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:left;color:#000000;">
                                     <h1>Verify Your Email</h1>
                                     <p> Thank you for creating an account with ${realmName}. Please complete the account verification process by clicking this link:</p>
                                   </div>
@@ -159,7 +161,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#A31F34" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#A31F34;" valign="middle">
-                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:Inter, Arial;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Verify Your Email </a>
+                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:neue-haas-grotesk-text, sans-serif;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Verify Your Email </a>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -168,7 +170,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:left;color:#000000;">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:left;color:#000000;">
                                     <p>Welcome and thanks!<br /><b>${realmName} Team</b></p>
                                   </div>
                                 </td>
@@ -206,7 +208,7 @@
                                       </tr>
                                       <tr>
                                         <td align="center" style="font-size:0px;padding:10px 25px;padding-bottom:20px;word-break:break-word;">
-                                          <div style="font-family:Inter, Arial;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                          <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
                                         </td>
                                       </tr>
                                     </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/password-reset.ftl
@@ -58,9 +58,9 @@
     </style>
     <![endif]-->
   <!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" type="text/css">
+  <link href="https://use.typekit.net/lbk1xay.css" rel="stylesheet" type="text/css">
   <style type="text/css">
-    @import url(https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap);
+    @import url(https://use.typekit.net/lbk1xay.css);
 
   </style>
   <!--<![endif]-->
@@ -99,6 +99,8 @@
     }
 
   </style>
+  <!-- Font files for Adobe Neue Haas Grotesk.
+    WARNING: This is linked to chudzick@mit.edu's Adobe account. -->
 </head>
 
 <body style="word-spacing:normal;background-color:#F3F4F8;">
@@ -121,7 +123,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
                                       <img src="${url.resourcesUrl}/img/MITlearn.png" height="29" width="103" alt="MIT Learn" />
                                     </a></div>
                                 </td>
@@ -147,7 +149,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:left;color:#000000;">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:left;color:#000000;">
                                     <h1>Reset Your Password</h1>
                                     <p> You're receiving this because you requested a password reset for your user account at ${realmName}. </p>
                                     <p>Please go to the following page and choose a new password:</p>
@@ -160,7 +162,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#A31F34" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#A31F34;" valign="middle">
-                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:Inter, Arial;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Reset Password </a>
+                                          <a href="${link}" style="display:inline-block;background:#A31F34;color:#FFFFFF;font-family:neue-haas-grotesk-text, sans-serif;font-size:14px;font-weight:bold;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank"> Reset Password </a>
                                         </td>
                                       </tr>
                                     </tbody>
@@ -169,7 +171,7 @@
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:left;color:#000000;">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:left;color:#000000;">
                                     <p> If the button doesn't work, copy and paste this link into your web browser: </p>
                                     <p>${link}</p>
                                   </div>
@@ -208,7 +210,7 @@
                                       </tr>
                                       <tr>
                                         <td align="center" style="font-size:0px;padding:10px 25px;padding-bottom:20px;word-break:break-word;">
-                                          <div style="font-family:Inter, Arial;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                          <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
                                         </td>
                                       </tr>
                                     </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/html/template.ftl
@@ -59,9 +59,9 @@
     </style>
     <![endif]-->
   <!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" type="text/css">
+  <link href="https://use.typekit.net/lbk1xay.css" rel="stylesheet" type="text/css">
   <style type="text/css">
-    @import url(https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap);
+    @import url(https://use.typekit.net/lbk1xay.css);
 
   </style>
   <!--<![endif]-->
@@ -100,6 +100,8 @@
     }
 
   </style>
+  <!-- Font files for Adobe Neue Haas Grotesk.
+    WARNING: This is linked to chudzick@mit.edu's Adobe account. -->
 </head>
 
 <body style="word-spacing:normal;background-color:#F3F4F8;">
@@ -122,7 +124,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:center;color:#000000;"><a href="${msg(" homeUrl")}">
                                       <img src="${url.resourcesUrl}/img/MITlearn.png" height="29" width="103" alt="MIT Learn" />
                                     </a></div>
                                 </td>
@@ -148,7 +150,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                  <div style="font-family:Inter, Arial;font-size:13px;line-height:18px;text-align:left;color:#000000;">
+                                  <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:13px;line-height:18px;text-align:left;color:#000000;">
                                     <#nested>
                                   </div>
                                 </td>
@@ -186,7 +188,7 @@
                                       </tr>
                                       <tr>
                                         <td align="center" style="font-size:0px;padding:10px 25px;padding-bottom:20px;word-break:break-word;">
-                                          <div style="font-family:Inter, Arial;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
+                                          <div style="font-family:neue-haas-grotesk-text, sans-serif;font-size:12px;line-height:18px;text-align:center;color:#212326;"><b>${realmName}</b> &#x2022; 77 Massachusetts Ave &#x2022; Cambridge, MA 02139 &#x2022; USA</div>
                                         </td>
                                       </tr>
                                     </tbody>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/_head.mjml
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/email/mjml/includes/_head.mjml
@@ -1,11 +1,15 @@
 <mj-head>
+  <!--
+    Font files for Adobe Neue Haas Grotesk.
+    WARNING: This is linked to chudzick@mit.edu's Adobe account.
+  -->
   <mj-font
-    name="Inter"
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
+    name="neue-haas-grotesk-text"
+    href="https://use.typekit.net/lbk1xay.css"
   />
   <mj-attributes>
     <mj-text line-height="18px"/>
-    <mj-all font-family="Inter, Arial" font-size="13px" />
+    <mj-all font-family="neue-haas-grotesk-text, sans-serif" font-size="13px" />
   </mj-attributes>
   <mj-style>
     h1 { color: #212326; }

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-username.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-username.ftl
@@ -1,70 +1,69 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
-    <#if section = "header">
-        ${msg("loginAccountTitle")}
-    <#elseif section = "form">
-        <div id="kc-form">
-            <div id="kc-form-wrapper">
-                <#if realm.password>
-                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
-                        method="post" class="${properties.kcFormClass}">
-                        <#if !usernameHidden??>
-                            <div class="${properties.kcFormGroupClass!}">
-                                <label for="username"
-                                       class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password &&
+  realm.registrationAllowed && !registrationDisabled??); section>
+  <#if section="header">
+    ${msg("loginAccountTitle")}
+  <#elseif section="form">
+    <div id="kc-form">
+      <div id="kc-form-wrapper">
+        <#if realm.password>
+          <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+            method="post" class="${properties.kcFormClass}">
+            <#if !usernameHidden??>
+              <div class="${properties.kcFormGroupClass!}">
+                <label for="username" class="${properties.kcLabelClass!}">
+                  <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>
+                      ${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                </label>
 
-                                <input id="username"
-                                       aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
-                                       class="${properties.kcInputClass!}" name="username"
-                                       value="${(login.username!'')}"
-                                       type="text" autofocus autocomplete="off"/>
+                <input id="username" aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                  class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text"
+                  autofocus autocomplete="off" />
 
-                                <#if messagesPerField.existsError('username')>
-                                    <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                        ${kcSanitize(messagesPerField.get('username'))?no_esc}
-                                    </span>
-                                </#if>
-                            </div>
-                        </#if>
-
-                        <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                            <div id="kc-form-options">
-                                <#if realm.rememberMe && !usernameHidden??>
-                                    <div class="checkbox">
-                                        <label>
-                                            <#if login.rememberMe??>
-                                                <input  id="rememberMe" name="rememberMe" type="checkbox"
-                                                       checked> ${msg("rememberMe")}
-                                            <#else>
-                                                <input  id="rememberMe" name="rememberMe"
-                                                       type="checkbox"> ${msg("rememberMe")}
-                                            </#if>
-                                        </label>
-                                    </div>
-                                </#if>
-                            </div>
-                        </div>
-
-                        <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                            <input
-                                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
-                                   name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                        </div>
-                    </form>
+                <#if messagesPerField.existsError('username')>
+                  <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}"
+                    aria-live="polite">
+                    ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                  </span>
                 </#if>
+              </div>
+            </#if>
+
+            <#if realm.rememberMe && !usernameHidden??>
+              <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                <div id="kc-form-options">
+                  <div class="checkbox">
+                    <label>
+                      <#if login.rememberMe??>
+                        <input id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                        <#else>
+                          <input id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                      </#if>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </#if>
+
+            <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+              <input
+                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                name="login" id="kc-login" type="submit" value="${msg('doLogIn')}" />
+              <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+                <div id="kc-registration">
+                  <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                </div>
+              </#if>
             </div>
-        </div>
-    <#elseif section = "socialProviders" >
-        <div class="separator pf-v5-u-py-md">
-            <span class="pf-v5-u-px-md">or</span>
-        </div>
-        <#include "social-providers.ftl">
-    <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-            <div id="kc-registration">
-                <span>${msg("noAccount")} <a  href="${url.registrationUrl}">${msg("doRegister")}</a></span>
-            </div>
+          </form>
         </#if>
-    </#if>
+      </div>
+    </div>
+  <#elseif section="socialProviders">
+    <div class="separator pf-v5-u-py-md">
+      <span class="pf-v5-u-px-md">or</span>
+    </div>
+    <#include "social-providers.ftl">
+  </#if>
 
 </@layout.registrationLayout>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-verify-email.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login-verify-email.ftl
@@ -7,13 +7,17 @@
           ${msg("emailVerifyInstruction1")}
         </p>
     <#elseif section = "info">
-        <p class="pf-v5-u-my-md">${msg("emailVerifyInstruction2")}</p>
-        <hr />
-        <p class="pf-v5-u-my-md">${msg("emailVerifyInstruction3")}</p>
-        <p class="pf-v5-u-my-md">
-            <b>${msg("emailVerifyInstruction4Bold")}</b>
-            ${msg("emailVerifyInstruction4")}
-            <a href="#">${msg("emailVerifySupportLinkTitle")}</a>.
-        </p>
+        <div id="kc-info" class="${properties.kcSignUpClass!}">
+          <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
+            <p class="pf-v5-u-my-md">${msg("emailVerifyInstruction2")}</p>
+            <hr />
+            <p class="pf-v5-u-my-md">${msg("emailVerifyInstruction3")}</p>
+            <p class="pf-v5-u-my-md">
+                <b>${msg("emailVerifyInstruction4Bold")}</b>
+                ${msg("emailVerifyInstruction4")}
+                <a href="#">${msg("emailVerifySupportLinkTitle")}</a>.
+            </p>
+        </div>
+      </div>
     </#if>
 </@layout.registrationLayout>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -137,9 +137,13 @@
     <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
     <#elseif section="info">
       <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-        <div id="kc-registration-container">
-          <div id="kc-registration">
-            <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+        <div id="kc-info" class="${properties.kcSignUpClass!}">
+          <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
+            <div id="kc-registration-container">
+              <div id="kc-registration">
+                <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+              </div>
+            </div>
           </div>
         </div>
       </#if>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -1,141 +1,153 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
-    <#if section = "header">
-        <#if loginAttempt.userFullname?has_content>
-            ${msg("loginGreeting")} ${loginAttempt.userFullname}!
+  <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password')
+    displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
+    <#if section="header">
+      <#if loginAttempt.userFullname?has_content>
+        ${msg("loginGreeting")} ${loginAttempt.userFullname}!
         <#else>
-            ${msg("loginAccountTitle")}
-        </#if>
-    <#elseif section = "form">
+          ${msg("loginAccountTitle")}
+      </#if>
+      <#elseif section="form">
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password && !social.providers??>
-                <#if !loginAttempt.needsPassword>
-                    <form id="kc-form-login" class="${properties.kcFormClass!} onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                        <#if !usernameHidden??>
-                            <div class="${properties.kcFormGroupClass!}">
-                                <label for="username" class="${properties.kcLabelClass!}">
-                                    <span class="pf-v5-c-form__label-text">
-                                        <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
-                                    </span>
-                                </label>
+              <#if !loginAttempt.needsPassword>
+                <form id="kc-form-login" class="${properties.kcFormClass!} onsubmit=" login.disabled=true; return true;"
+                  action="${url.loginAction}" method="post">
+                  <#if !usernameHidden??>
+                    <div class="${properties.kcFormGroupClass!}">
+                      <label for="username" class="${properties.kcLabelClass!}">
+                        <span class="pf-v5-c-form__label-text">
+                          <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif
+                              !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+                        </span>
+                      </label>
 
-                                <span class="${properties.kcInputClass!} ${messagesPerField.existsError('username','password')?then('pf-m-error', '')}">
-                                    <input id="username" name="username" value="${(login.username!'')}" type="email" autofocus autocomplete="off"
-                                           aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                                    />
-                                    <#if messagesPerField.existsError('username','password')>
-                                        <span class="pf-v5-c-form-control__utilities">
-                                            <span class="pf-v5-c-form-control__icon pf-m-status">
-                                            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-                                            </span>
-                                        </span>
-                                    </#if>
-                                </span>
-
-                                <#if messagesPerField.existsError('username','password')>
-                                    <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                            ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
-                                    </span>
-                                </#if>
-
-                            </div>
+                      <span
+                        class="${properties.kcInputClass!} ${messagesPerField.existsError('username','password')?then('pf-m-error', '')}">
+                        <input id="username" name="username" value="${(login.username!'')}" type="email" autofocus
+                          autocomplete="off"
+                          aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>" />
+                        <#if messagesPerField.existsError('username','password')>
+                          <span class="pf-v5-c-form-control__utilities">
+                            <span class="pf-v5-c-form-control__icon pf-m-status">
+                              <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+                            </span>
+                          </span>
                         </#if>
+                      </span>
 
-                        <div class="${properties.kcFormGroupClass!}">
-                            <label for="password" class="${properties.kcLabelClass!}">
-                                <span class="pf-v5-c-form__label-text">${msg("password")}</span>
-                            </label>
+                      <#if messagesPerField.existsError('username','password')>
+                        <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                          ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                        </span>
+                      </#if>
 
-                            <div class="${properties.kcInputGroup!} password-toggle-field">
-                                <input id="password" name="password" type="password" autocomplete="off"
-                                       aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
-                                       class="${properties.kcInputClass!}"
-                                />
-                                <div class="toggle-password-button">
-                                    <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="${msg('showPassword')}"
-                                            aria-controls="password" data-password-toggle
-                                            data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}" data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
-                                            data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
-                                        <i class="${properties.kcFormPasswordVisibilityIconShow!}" aria-hidden="true"></i>
-                                    </button>
-                                </div>
-                            </div>
-
-                            <#if usernameHidden?? && messagesPerField.existsError('username','password')>
-                                <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
-                                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
-                                </span>
-                            </#if>
-
-                        </div>
-
-                        <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                            <div id="kc-form-options">
-                                <#if realm.rememberMe && !usernameHidden??>
-                                    <div class="checkbox">
-                                        <label>
-                                            <span class="pf-v5-c-form__label-text">
-                                            <#if login.rememberMe??>
-                                                <input id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
-                                            <#else>
-                                                <input id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
-                                            </#if>
-                                            </span>
-                                        </label>
-                                    </div>
-                                </#if>
-                                </div>
-                                <div class="${properties.kcFormOptionsWrapperClass!}">
-                                    <#if realm.resetPasswordAllowed>
-                                        <span><a href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
-                                    </#if>
-                                </div>
-
-                          </div>
-
-                          <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                              <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
-                              <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                          </div>
-                    </form>
-                  <#elseif realm.resetPasswordAllowed>
-                      <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginResetCredentialsUrl}" method="get" class="${properties.kcFormClass!}">
-                          <div class="${properties.kcFormGroupClass!}">
-                              <p>
-                                  <b>Password required.</b>
-                                  For security reasons you will need to create a new password for your account.
-                              </p>
-                          </div>
-                          <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                              <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" id="kc-create-password" type="submit">
-                                  ${msg("createPassword")}
-                              </button>
-                          </div>
-                      </form>
-                  <#else>
-                      <div class="${properties.kcFormGroupClass!}">
-                          <p>Unable to log you in - no password and password reset is disabled by the administrator.</p>
-                      </div>
+                    </div>
                   </#if>
-                </#if>
-            </div>
+
+                  <div class="${properties.kcFormGroupClass!}">
+                    <label for="password" class="${properties.kcLabelClass!}">
+                      <span class="pf-v5-c-form__label-text">${msg("password")}</span>
+                    </label>
+
+                    <div class="${properties.kcInputGroup!} password-toggle-field">
+                      <input id="password" name="password" type="password" autocomplete="off"
+                        aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                        class="${properties.kcInputClass!}" />
+                      <div class="toggle-password-button">
+                        <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button"
+                          aria-label="${msg('showPassword')}" aria-controls="password" data-password-toggle
+                          data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}"
+                          data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
+                          data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
+                          <i class="${properties.kcFormPasswordVisibilityIconShow!}" aria-hidden="true"></i>
+                        </button>
+                      </div>
+                    </div>
+
+                    <#if usernameHidden?? && messagesPerField.existsError('username','password')>
+                      <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                        ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                      </span>
+                    </#if>
+
+                  </div>
+
+                  <#if (realm.rememberMe && !usernameHidden) || realm.resetPasswordAllowed>
+                    <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                      <#if realm.rememberMe && !usernameHidden??>
+                        <div id="kc-form-options">
+                          <div class="checkbox">
+                            <label>
+                              <span class="pf-v5-c-form__label-text">
+                                <#if login.rememberMe??>
+                                  <input id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                  <#else>
+                                    <input id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                </#if>
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+                      </#if>
+                      <#if realm.resetPasswordAllowed>
+                        <div class="${properties.kcFormOptionsWrapperClass!}">
+                          <span><a href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                        </div>
+                      </#if>
+
+                    </div>
+                  </#if>
+
+                  <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                    <input type="hidden" id="id-hidden-input" name="credentialId" <#if
+                      auth.selectedCredential?has_content>value="${auth.selectedCredential}"
+              </#if>/>
+              <input
+                class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                name="login" id="kc-login" type="submit" value="${msg(" doLogIn")}" />
+          </div>
+          </form>
+          <#elseif realm.resetPasswordAllowed>
+            <form id="kc-form-login" onsubmit="login.disabled = true; return true;"
+              action="${url.loginResetCredentialsUrl}" method="get" class="${properties.kcFormClass!}">
+              <div class="${properties.kcFormGroupClass!}">
+                <p>
+                  <b>Password required.</b>
+                  For security reasons you will need to create a new password for your account.
+                </p>
+              </div>
+              <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                <button
+                  class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                  id="kc-create-password" type="submit">
+                  ${msg("createPassword")}
+                </button>
+              </div>
+            </form>
+            <#else>
+              <div class="${properties.kcFormGroupClass!}">
+                <p>Unable to log you in - no password and password reset is disabled by the administrator.</p>
+              </div>
+    </#if>
+    </#if>
+    </div>
+    </div>
+    <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+    <#elseif section="info">
+      <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+        <div id="kc-registration-container">
+          <div id="kc-registration">
+            <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+          </div>
         </div>
-        <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
-    <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-            <div id="kc-registration-container">
-                <div id="kc-registration">
-                    <span>${msg("noAccount")} <a
-                                                 href="${url.registrationUrl}">${msg("doRegister")}</a></span>
-                </div>
-            </div>
-        </#if>
-    <#elseif section = "socialProviders" >
+      </#if>
+      <#elseif section="socialProviders">
         <#if realm.password && social.providers??>
-            <p class="pf-v5-u-font-weight-bold pf-v5-u-mb-sm">You already have a login with:</p>
+          <p class="pf-v5-u-font-weight-bold pf-v5-u-mb-sm">You already have a login with:</p>
         </#if>
         <#include "social-providers.ftl">
-    </#if>
+          </#if>
 
-</@layout.registrationLayout>
+  </@layout.registrationLayout>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
@@ -145,7 +145,7 @@
             <#if recaptchaRequired??>
                 <div class="form-group">
                     <div class="${properties.kcInputWrapperClass!}">
-                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                        <div class="g-recaptcha" data-sitekey="${recaptchaSiteKey}" data-theme="light"></div>
                     </div>
                 </div>
             </#if>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
@@ -162,6 +162,20 @@
             </div>
         </form>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+        <script type="text/javascript">
+        function resizeRecaptcha() {
+            var recaptcha = document.querySelector(".g-recaptcha");
+            var parent = recaptcha.parentElement;
+            var newScaleFactor = parent.offsetWidth / 302;
+            recaptcha.style.transform = 'scale(' + newScaleFactor + ')';
+            recaptcha.style.transformOrigin = '0 0';
+            // transforms don't contribute to flow so we need to manually resize the parent to match
+            parent.style.height = (newScaleFactor * 76) + "px";
+        }
+
+        window.addEventListener("resize", resizeRecaptcha);
+        window.addEventListener("load", resizeRecaptcha);
+        </script>
     </#if>
     <#if section = "socialProviders" >
       <div class="separator pf-v5-u-py-md">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
@@ -154,8 +154,12 @@
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegisterSubmit")}"/>
                 </div>
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span>${msg('alreadyHaveAnAccountRegister')} <a href="${url.loginUrl}">${kcSanitize(msg("logInRegister"))?no_esc}</a></span>
+                    </div>
+                </div>
             </div>
-
         </form>
         <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
     </#if>
@@ -167,12 +171,6 @@
     </#if>
     <#if section = "footer">
         <div class="${properties.kcFormGroupClass!}">
-            <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-                <div class="${properties.kcFormOptionsWrapperClass!}">
-                    <span>${msg('alreadyHaveAnAccountRegister')} <a href="${url.loginUrl}">${kcSanitize(msg("logInRegister"))?no_esc}</a></span>
-                </div>
-            </div>
-
             <div id="kc-form-legal-options" class="${properties.kcFormOptionsClass!}">
                 <div class="${properties.kcFormOptionsWrapperClass!}">
       <span class="pf-v5-u-font-size-xs">${msg('registerLegalAgreementText')} <a href="${olSettings.privacyPolicyUrl!"#"}" class="pf-v5-u-font-size-xs">${kcSanitize(msg("registerPrivacyPolicy"))?no_esc}</a>.</span>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -248,10 +248,6 @@ main {
   letter-spacing: -0.1px;
 }
 
-.login-pf #kc-login {
-  margin-top: 20px;
-}
-
 .login-pf-page .login-pf-signup a {
   margin-left: 0px;
 }
@@ -289,17 +285,22 @@ main {
   margin: auto;
 }
 
-#social-touchstone-idp {
+#kc-form-buttons {
   display: flex;
-  align-items: center;
+  gap: 4px;
+  flex-direction: column;
+  margin-block-start: 0;
 }
 
-#social-touchstone-idp svg {
-  margin-left: auto;
+#kc-registration {
+  font-size: 14px;
 }
 
-#social-touchstone-idp span {
-  margin-right: auto;
+#social-touchstone-idp {
+  display: inline-flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 13px;
   font-weight: 500;
 }
 
@@ -322,13 +323,13 @@ main {
 }
 
 .footer {
-  display: inline-flex;
+  display: flex;
   justify-content: center;
   color: var(--Brand-Dark-Silver-Gray);
   align-items: center;
   gap: 10px;
   width: 100%;
-  flex-direction: row-reverse;
+  flex-direction: column;
   font-size: 12px;
 }
 
@@ -359,13 +360,14 @@ main {
   display: flex;
   align-items: center;
   text-align: center;
+  color: var(Brand-Dark-Gray-2);
 }
 
 .separator::before,
 .separator::after {
   content: "";
   flex: 1;
-  border-bottom: 1px solid var(--Brand-Dark-Gray-2);
+  border-bottom: 1px solid var(--Brand-Light-Silver-Gray);
 }
 
 .separator:not(:empty)::before {
@@ -399,4 +401,15 @@ main {
 
 #kc-form-legal-options {
   color: var(--Brand-Dark-Silver-Gray);
+}
+
+.sign-up-suggest {
+  color: var(--Brand-Dark-Silver-Gray);
+}
+
+.g-recaptcha iframe {
+  border: var(--Brand-Light-Silver-Gray);
+  border-radius: 5px;
+  width: 302px;
+  height: 76px;
 }

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -289,7 +289,7 @@ main {
   display: flex;
   gap: 4px;
   flex-direction: column;
-  margin-block-start: 0;
+  margin-block-start: 0 !important;
 }
 
 #kc-registration {
@@ -407,9 +407,27 @@ main {
   color: var(--Brand-Dark-Silver-Gray);
 }
 
+/*
+* upscale the recaptcha to match the form width
+* note that we also dynamically resize this in JS to get more accurate and to support mobile widths
+* */
+.g-recaptcha {
+  transform-origin: 0 0;
+  transform: scale(1.24);
+}
+
 .g-recaptcha iframe {
-  border: var(--Brand-Light-Silver-Gray);
+  /* tighter border-radius to crop out the black background at the corners */
   border-radius: 5px;
+  /* downsize the iframe to crop out black background on bottom and right of recaptcha */
   width: 302px;
   height: 76px;
+}
+/* undo some patternfly styles that are clobbering the layout */
+@media (min-width: 1200px) {
+  .pf-v5-c-login__container {
+    display: block;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
+  }
 }

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -39,6 +39,10 @@
 
   --pf-v5-global--danger-color--100: var(--Brand-Light-Red);
 
+  --pf-v5-global--FontFamily--text: "neue-haas-grotesk-text", sans-serif;
+  --pf-v5-global--FontFamily--heading: "neue-haas-grotesk-text", sans-serif;
+  --pf-v5-global--FontFamily--text--vf: "neue-haas-grotesk-text", sans-serif;
+  --pf-v5-global--FontFamily--heading--vf: "neue-haas-grotesk-text", sans-serif;
 }
 
 .pf-v5-c-alert {
@@ -68,7 +72,6 @@
 }
 
 @media (max-width: 500px) {
-
   .pf-v5-c-login .pf-v5-c-login__main-header {
     padding-top: 10px;
   }
@@ -81,7 +84,7 @@
 }
 
 .pf-v5-c-form {
-  --pf-v5-c-form--GridGap: 0.3rem;
+  --pf-v5-c-form--GridGap: 24px;
 }
 
 .pf-v5-c-login__main-footer {
@@ -90,6 +93,7 @@
 }
 
 .pf-v5-c-form-control {
+  margin-top: 4px;
   border-radius: 4px;
   border: 0;
   background: var(--Brand-White);
@@ -114,6 +118,12 @@
 }
 
 .pf-v5-c-button {
+  --pf-v5-c-button--FontWeight: 500;
+  --pf-v5-c-button--FontSize: 16px;
+
+  --pf-v5-c-button--PaddingTop: 16px;
+  --pf-v5-c-button--PaddingBottom: 16px;
+
   --pf-v5-c-button--m-primary--Color: var(--Brand-White);
   --pf-v5-c-button--m-primary--BackgroundColor: var(--Brand-MIT-Red);
   --pf-v5-c-button--m-primary--hover--BackgroundColor: var(--Brand-Red);
@@ -145,12 +155,12 @@ a.pf-v5-c-button:visited {
 
 
 .pf-v5-c-title.pf-m-3xl {
-  color: var(--Brand-Dark-Gray-1)
+  color: var(--Brand-Dark-Gray-2);
+  font-size: 24px;
 }
 
 .login-pf {
   background: var(--Brand-White);
-  font-family: Inter;
 }
 
 .login-pf body {
@@ -199,7 +209,6 @@ main {
   text-edge: cap;
 
   /* Heading */
-  font-family: Inter;
   font-size: 22px;
   font-style: normal;
   font-weight: 700;
@@ -213,7 +222,6 @@ main {
   text-edge: cap;
 
   /* Heading */
-  font-family: Inter;
   font-size: 22px;
   font-style: normal;
   font-weight: 700;
@@ -227,7 +235,6 @@ main {
   text-edge: cap;
 
   /* Subheading */
-  font-family: Inter;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -263,6 +270,7 @@ main {
 .pf-v5-c-form__label-text {
   font-weight: normal !important;
   font-size: 16px;
+  color: var(--Brand-Dark-Gray-2);
 }
 
 #kc-header {
@@ -299,7 +307,6 @@ main {
 }
 
 .login-pf-page .login-pf-signup span {
-  font-family: Inter;
   font-size: 14px;
   font-weight: 400;
   line-height: 20px;
@@ -313,10 +320,15 @@ main {
   display: inline-flex;
   padding: 96px 10px 50px 10px;
   justify-content: center;
+  color: var(--Brand-Dark-Silver-Gray);
   align-items: center;
   gap: 10px;
   width: 100%;
   flex-direction: row-reverse;
+}
+
+.copyright {
+  font-size: 12px;
 }
 
 @media (max-width: 768px) {
@@ -336,7 +348,6 @@ main {
   text-edge: cap;
 
   /* Default */
-  font-family: Inter;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
@@ -350,7 +361,6 @@ main {
   color: var(--Brand-Red);
   leading-trim: both;
   text-edge: cap;
-  font-family: Inter;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
@@ -369,7 +379,7 @@ main {
 .separator::after {
   content: "";
   flex: 1;
-  border-bottom: 1px solid #d5dae1;
+  border-bottom: 1px solid var(--Brand-Dark-Gray-2);
 }
 
 .separator:not(:empty)::before {
@@ -388,6 +398,10 @@ main {
 .password-toggle-field .toggle-password-button {
   position: absolute;
   right: 1px;
+}
+
+.toggle-password-button .pf-v5-c-button {
+  padding: 12px;
 }
 
 .instruction {

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -100,7 +100,7 @@
   border-radius: 4px;
   border: 0;
   background: var(--Brand-White);
-  color: var(--Brand-Light-Silver-Gray);
+  color: var(--Brand-Dark-Gray-2);
   -webkit-box-shadow: inset 0px 0px 0px 2px var(--Brand-Light-Silver-Gray);
   -moz-box-shadow: inset 0px 0px 0px 2px var(--Brand-Light-Silver-Gray);
   box-shadow: inset 0px 0px 0px 2px var(--Brand-Light-Silver-Gray);
@@ -109,7 +109,6 @@
 .pf-v5-c-form-control:focus, .pf-v5-c-form-control:hover, .pf-v5-c-form-control:active {
   border-width: 2px;
   padding: 0;
-  color: var(--Brand-Dark-Gray-2);
   outline: none;
   -webkit-box-shadow: inset 0px 0px 0px 2px var(--Brand-Dark-Gray-2);
   -moz-box-shadow: inset 0px 0px 0px 2px var(--Brand-Dark-Gray-2);
@@ -287,7 +286,7 @@ main {
 
 #kc-form-buttons {
   display: flex;
-  gap: 4px;
+  gap: 8px;
   flex-direction: column;
   margin-block-start: 0 !important;
 }
@@ -401,6 +400,11 @@ main {
 }
 
 #kc-form-legal-options {
+  color: var(--Brand-Dark-Silver-Gray);
+}
+
+#kc-form-options {
+  font-size: 14px;
   color: var(--Brand-Dark-Silver-Gray);
 }
 

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -299,6 +299,7 @@ main {
 #social-touchstone-idp {
   display: inline-flex;
   justify-content: center;
+  align-items: center;
   gap: 8px;
   padding: 13px;
   font-weight: 500;

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -61,17 +61,17 @@
 }
 
 .pf-v5-c-login {
-  --pf-v5-c-login__container--MaxWidth: 440px;
+  --pf-v5-c-login__container--MaxWidth: 600px;
 
-  --pf-v5-c-login__main-header--PaddingRight: 16px;
-  --pf-v5-c-login__main-header--PaddingLeft: 16px;
+  --pf-v5-c-login__main-header--PaddingRight: 32px;
+  --pf-v5-c-login__main-header--PaddingLeft: 32px;
   --pf-v5-c-login__main-header--PaddingTop: 80px;
   --pf-v5-c-login__main-header--PaddingBottom: 0;
 
   --pf-v5-c-login__main-body--PaddingBottom: 0;
 
-  --pf-v5-c-login__main-body--PaddingRight: 16px;
-  --pf-v5-c-login__main-body--PaddingLeft: 16px;
+  --pf-v5-c-login__main-body--PaddingRight: 32px;
+  --pf-v5-c-login__main-body--PaddingLeft: 32px;
 }
 
 @media (max-width: 500px) {

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/resources/css/styles.css
@@ -43,6 +43,8 @@
   --pf-v5-global--FontFamily--heading: "neue-haas-grotesk-text", sans-serif;
   --pf-v5-global--FontFamily--text--vf: "neue-haas-grotesk-text", sans-serif;
   --pf-v5-global--FontFamily--heading--vf: "neue-haas-grotesk-text", sans-serif;
+
+  --pf-v5-global--LineHeight--md: 16px;
 }
 
 .pf-v5-c-alert {
@@ -64,6 +66,7 @@
   --pf-v5-c-login__main-header--PaddingRight: 16px;
   --pf-v5-c-login__main-header--PaddingLeft: 16px;
   --pf-v5-c-login__main-header--PaddingTop: 80px;
+  --pf-v5-c-login__main-header--PaddingBottom: 0;
 
   --pf-v5-c-login__main-body--PaddingBottom: 0;
 
@@ -169,8 +172,11 @@ a.pf-v5-c-button:visited {
 }
 
 main {
+  display: flex;
+  flex-direction: column;
   margin: auto;
   padding: 0 16px 16px;
+  gap: 24px;
 }
 
 .login-pf #kc-header {
@@ -315,19 +321,14 @@ main {
   color: #5f6368;
 }
 
-/* footer styles START */
 .footer {
   display: inline-flex;
-  padding: 96px 10px 50px 10px;
   justify-content: center;
   color: var(--Brand-Dark-Silver-Gray);
   align-items: center;
   gap: 10px;
   width: 100%;
   flex-direction: row-reverse;
-}
-
-.copyright {
   font-size: 12px;
 }
 
@@ -341,21 +342,6 @@ main {
   display: flex;
   gap: 10px;
 }
-
-.footer span {
-  color: #000;
-  leading-trim: both;
-  text-edge: cap;
-
-  /* Default */
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px; /* 142.857% */
-  letter-spacing: -0.1px;
-}
-
-/* footer styles END */
 
 #input-error {
   color: var(--Brand-Red);

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -6,6 +6,11 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="robots" content="noindex, nofollow">
+    <!--
+      Font files for Adobe Neue Haas Grotesk.
+      WARNING: This is linked to chudzick@mit.edu's Adobe account.
+    -->
+    <link rel="stylesheet" href="https://use.typekit.net/lbk1xay.css" />
 
     <#if properties.meta?has_content>
         <#list properties.meta?split(' ') as meta>
@@ -45,9 +50,6 @@
             );
         </script>
     </#if>
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap')
-    </style>
 </head>
 
 <body id="keycloak-bg" class="${properties.kcBodyClass!}">
@@ -107,7 +109,7 @@
             </div>
         </#if>
 
-        <h2 class="pf-v5-c-title pf-m-3xl"><#nested "header"></h2>
+        <h4 class="pf-v5-c-title pf-m-3xl"><#nested "header"></h4>
 
         <#if realm.internationalizationEnabled  && locale.supported?size gt 1>
         <div class="pf-v5-c-login__main-header-utilities">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -192,19 +192,17 @@
               </div>
           </div>
         </#if>
-      </div>
-      <div class="pf-v5-c-login__main-footer">
         <#nested "socialProviders">
         <#nested "footer">
       </div>
       <footer class="footer">
-          <div id="footer-links">
-          </div>
-          <div id="copywrite">
+          <div id="copyright">
               <span>
-                ©${.now?string('yyyy')} Massachusetts Institute of Technology, All Rights Reserved.
-                <a href="${olSettings.privacyPolicyUrl}">${msg("registerPrivacyPolicy")}</a>
+                <em>${realm.displayName}</em> &#x2022; 77 Massachusetts Avenue &#x2022; Cambridge, MA 02139 &#x2022; USA
               </span>
+          </div>
+          <div id="footer-links">
+            <a href="${olSettings.privacyPolicyUrl}">${msg("registerPrivacyPolicy")}</a>
           </div>
       </footer>
     </main>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -186,11 +186,7 @@
         </#if>
 
         <#if displayInfo>
-          <div id="kc-info" class="${properties.kcSignUpClass!}">
-              <div id="kc-info-wrapper" class="${properties.kcInfoAreaWrapperClass!}">
-                  <#nested "info">
-              </div>
-          </div>
+            <#nested "info">
         </#if>
         <#nested "socialProviders">
         <#nested "footer">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -198,7 +198,7 @@
       <footer class="footer">
           <div id="copyright">
               <span>
-                <em>${realm.displayName}</em> &#x2022; 77 Massachusetts Avenue &#x2022; Cambridge, MA 02139 &#x2022; USA
+                <strong>${realm.displayName}</strong> &#x2022; 77 Massachusetts Avenue &#x2022; Cambridge, MA 02139 &#x2022; USA
               </span>
           </div>
           <div id="footer-links">


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5338

### Description (What does it do?)
<!--- Describe your changes in detail -->
This addresses a variety of style tweaks to align the UX to the latest UX mockups.

Note that I also had to do some hackery with javascript to get the recaptcha to size correctly. This won't exactly match the mockups because we don't have control over the recaptcha CSS itself, so the best we can do is scale it as best as possible.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
![Screenshot 2024-09-06 at 15-05-56 MIT Learn](https://github.com/user-attachments/assets/b18d1282-3ab2-4db5-ba4b-15478058f60b)

![Screenshot 2024-09-06 at 14-58-50 MIT Learn](https://github.com/user-attachments/assets/f83a79c8-b04c-44c2-a823-5be1914559f0)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Go to the login page and verify it looks like the mockups
- Go to the registration page and verify it looks like the mockups and that the recaptcha scales over various browser widths