### PR TITLE
Fix reset button label

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -106,7 +106,7 @@
               </#if>/>
               <input
                 class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
-                name="login" id="kc-login" type="submit" value="${msg(" doLogIn")}" />
+                name="login" id="kc-login" type="submit" value="${msg("doLogIn")}" />
           </div>
           </form>
           <#elseif realm.resetPasswordAllowed>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/5700

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes a typo that was causing the button label to default to the message name.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Go to reset your password and verify the button actually shows the correct label.
