### PR TITLE
Fixes for Keycloak 26.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ node_modules/
 
 # java
 .classpath
+.factorypath
 .project
 .settings/

--- a/ol-keycloak/ol-spi/pom.xml
+++ b/ol-keycloak/ol-spi/pom.xml
@@ -19,17 +19,17 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>25.0.6</version>
+            <version>26.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>25.0.6</version>
+            <version>26.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>25.0.6</version>
+            <version>26.0.5</version>
         </dependency>
     </dependencies>
 

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/header.ftl
@@ -1,6 +1,6 @@
 <div class="pf-v5-l-flex pf-m-justify-content-space-between">
   <h1 class="pf-v5-l-flex__item">
-    <a href="${olSettings.homeUrl!" #"}">
+    <a href="${(olSettings.homeUrl)!'#'}">
       <img src="${url.resourcesPath}/img/mit-learn-logo.png" height="24" width="132" alt="MIT Learn" />
     </a>
   </h1>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -10,7 +10,7 @@
       <#elseif section="form">
         <div id="kc-form">
           <div id="kc-form-wrapper">
-            <#if realm.password && !social.providers??>
+            <#if realm.password && social.providers?size == 0>
               <#if !loginAttempt.needsPassword>
                 <form id="kc-form-login" class="${properties.kcFormClass!} onsubmit=" login.disabled=true; return true;"
                   action="${url.loginAction}" method="post">
@@ -148,7 +148,7 @@
         </div>
       </#if>
       <#elseif section="socialProviders">
-        <#if realm.password && social.providers??>
+        <#if realm.password && social.providers?size != 0>
           <p class="pf-v5-u-font-weight-bold pf-v5-u-mb-sm">You already have a login with:</p>
         </#if>
         <#include "social-providers.ftl">

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/register.ftl
@@ -170,7 +170,7 @@
         <div class="${properties.kcFormGroupClass!}">
             <div id="kc-form-legal-options" class="${properties.kcFormOptionsClass!}">
                 <div class="${properties.kcFormOptionsWrapperClass!}">
-      <span class="pf-v5-u-font-size-xs">${msg('registerLegalAgreementText')} <a href="${olSettings.privacyPolicyUrl!"#"}" class="pf-v5-u-font-size-xs">${kcSanitize(msg("registerPrivacyPolicy"))?no_esc}</a>.</span>
+      <span class="pf-v5-u-font-size-xs">${msg('registerLegalAgreementText')} <a href="${(olSettings.privacyPolicyUrl)!"#"}" class="pf-v5-u-font-size-xs">${kcSanitize(msg("registerPrivacyPolicy"))?no_esc}</a>.</span>
                 </div>
             </div>
         </div>

--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/template.ftl
@@ -178,7 +178,7 @@
               </span>
           </div>
           <div id="footer-links">
-            <a href="${olSettings.privacyPolicyUrl}">${msg("registerPrivacyPolicy")}</a>
+            <a href="${(olSettings.privacyPolicyUrl)!'#'}">${msg("registerPrivacyPolicy")}</a>
           </div>
       </footer>
     </main>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/ol-keycloak/issues/80

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a number of template fixes to address issues under 26.x:

- Usages of attributes defined by our freemarker SPI won't be present on error pages but the templates still get used so I made those null-safe.
- The library for freemarker templates must've been updated to a version where the truthiness of an empty sequence is no longer false, so I updated those `if` directives to check the size of `social.providers` instead.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Nothing visual has changed. You should still be able to login (with email and touchstone), register, and reset your password.