### PR TITLE
Fix issues w/ form not passing on auth state

### DIFF
--- a/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
+++ b/ol-keycloak/oltheme/src/main/resources/theme/ol/login/login.ftl
@@ -110,8 +110,7 @@
           </div>
           </form>
           <#elseif realm.resetPasswordAllowed>
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;"
-              action="${url.loginResetCredentialsUrl}" method="get" class="${properties.kcFormClass!}">
+            <div id="kc-form-login" class="${properties.kcFormClass!}">
               <div class="${properties.kcFormGroupClass!}">
                 <p>
                   <b>Password required.</b>
@@ -119,17 +118,18 @@
                 </p>
               </div>
               <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                <button
+                <a
+                  href="${url.loginResetCredentialsUrl}"
                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                   id="kc-create-password" type="submit">
                   ${msg("createPassword")}
-                </button>
+                </a>
               </div>
-            </form>
-            <#else>
-              <div class="${properties.kcFormGroupClass!}">
-                <p>Unable to log you in - no password and password reset is disabled by the administrator.</p>
-              </div>
+            </div>
+          <#else>
+            <div class="${properties.kcFormGroupClass!}">
+              <p>Unable to log you in - no password and password reset is disabled by the administrator.</p>
+            </div>
     </#if>
     </#if>
     </div>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5923

### Description (What does it do?)
<!--- Describe your changes in detail -->
This removes the html form + submit button combination because it needs to be a GET request but html forms erase the querystring when the method is GET. A plain anchor tag replaces it because this works the way it needs to.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- In keycloak, create a user with no credentials or remove credentials from an existing one
- Go to Learn, click "Login"
- Enter the email address for the above user
- You should be prompted to reset the password for that user
- Perform the password reset
- You should be redirected back to Learn instead of the keycloak account page