### PR TITLE
Add check for some cases where page is null

### DIFF
--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/OlFreeMarkerLoginFormsProvider.java
@@ -38,7 +38,7 @@ public class OlFreeMarkerLoginFormsProvider extends org.keycloak.forms.login.fre
 
         attributes.put("olSettings", new OLSettingsBean(realm));
 
-        if (page.equals(LOGIN)) {
+        if (page != null && page.equals(LOGIN)) {
             UserModel user = context.getUser();
             attributes.put("loginAttempt", new OLLoginAttemptBean(user));
         }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
We hit an issue trying to setup WebAuthn where the `page` is null when this method is called. We only care about it for the login form pages anyway, so I added this null check.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Login should still work
- I haven't tested this against WebAuthn, but the change is very innocuous.