### PR TITLE
feat: Add custom authenticator to check if an account has credentials

### DIFF
--- a/ol-keycloak/ol-spi/pom.xml
+++ b/ol-keycloak/ol-spi/pom.xml
@@ -24,13 +24,21 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
             <version>${keycloak.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/authentication/HasCredentialAuthenticator.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/authentication/HasCredentialAuthenticator.java
@@ -1,0 +1,77 @@
+package edu.mit.keycloak.authentication;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
+
+public class HasCredentialAuthenticator implements Authenticator {
+
+    public static final String PROVIDER_ID = "has-credential-authenticator";
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        UserModel user = context.getUser();
+        if (user == null) {
+            // This authenticator typically runs after a username/email has been provided
+            // If user is null, it.means no user context yet, which might be an error or
+            // an unexpected flow state for this specific authenticator's purpose.
+            // For this specific use case, we assume a user is already identified.
+            context.failure(AuthenticationFlowError.UNKNOWN_USER);
+            return;
+        }
+
+        // This checks if a user has a password credential, a federated identity (e.g.,
+        // linked social login, SAML, or OAuth provider),
+        // or is linked to an external user federation provider (like LDAP).
+        boolean hasPassword = user.credentialManager().getCredentials().anyMatch(
+                credential -> credential instanceof PasswordCredentialModel);
+        // Use getFederatedIdentities() and check if the list is empty
+        boolean hasFederatedIdentity = !user.credentialManager().getFederatedCredentialsStream().findAny()
+                .isEmpty();
+        boolean isFederatedUser = user.isFederated();
+
+        if (hasPassword || hasFederatedIdentity || isFederatedUser) {
+            context.success(); // User has at least one form of credential
+        } else {
+            // No password, no linked social/SAML/OIDC, and not an LDAP-backed user
+            // This user has no known way to authenticate directly.
+            context.failure(AuthenticationFlowError.INVALID_CREDENTIALS);
+            // You might want to add a challenge here to display a message to the user,
+            // e.g.,
+            // context.challenge(context.form().setError("noCredentialFound").createForm("login-no-credential.ftl"));
+            // This would require a custom FreeMarker template and message key.
+        }
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // This authenticator doesn't require user interaction, so this method can be
+        // empty.
+        authenticate(context); // Re-evaluate if action is triggered
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return true; // This authenticator needs a user context to operate
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        // This authenticator is always applicable if a user exists
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        // This authenticator doesn't set required actions
+    }
+
+    @Override // Added or ensured @Override
+    public void close() {
+        // No resources to close
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/authentication/HasCredentialAuthenticatorFactory.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/authentication/HasCredentialAuthenticatorFactory.java
@@ -1,0 +1,85 @@
+package edu.mit.keycloak.authentication;
+
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.ConfigurableAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.Config; // Correct import for Config.Scope
+
+import java.util.Collections;
+import java.util.List;
+
+public class HasCredentialAuthenticatorFactory implements AuthenticatorFactory, ConfigurableAuthenticatorFactory {
+
+    public static final String PROVIDER_ID = HasCredentialAuthenticator.PROVIDER_ID;
+
+    private static final Authenticator SINGLETON = new HasCredentialAuthenticator();
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Has Credential Check";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Checks if the user account has any form of credential (password, federated identity, or linked user federation). Fails if no credential is found.";
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[] {
+                AuthenticationExecutionModel.Requirement.REQUIRED,
+                AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                AuthenticationExecutionModel.Requirement.DISABLED
+        };
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList(); // No configurable properties for this authenticator
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false; // No configuration needed
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "condition"; // Or "flow" depending on how you want it categorized
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // Not needed for this simple authenticator
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // Not needed for this simple authenticator
+    }
+
+    @Override
+    public void close() {
+        // No resources to close
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        // This authenticator is for checking existing credentials, not for initial user setup.
+        return false;
+    }
+}

--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
@@ -28,6 +28,10 @@ public class OLLoginAttemptBean {
                 }
             });
 
+            if (user.isFederated()) {
+                this.needsPassword = false;
+            }
+
             // Check for linked identity providers
             Stream<FederatedIdentityModel> federatedIdentities =
                     session.users().getFederatedIdentitiesStream(realm, user);

--- a/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/ol-keycloak/ol-spi/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+edu.mit.keycloak.authentication.HasCredentialAuthenticatorFactory

--- a/ol-keycloak/ol-spi/src/test/java/OLLoginAttemptBeanTest.java
+++ b/ol-keycloak/ol-spi/src/test/java/OLLoginAttemptBeanTest.java
@@ -71,4 +71,24 @@ public class OLLoginAttemptBeanTest {
         assertTrue(bean.getNeedsPassword()); // no password credentials
         assertTrue(bean.getHasSocialProviderAuth()); // federated identity present
     }
+
+    @Test
+    public void testUserWithNoPasswordAndFederatedStorage() {
+        // Mock SubjectCredentialManager with no credentials
+        SubjectCredentialManager mockCredentialManager = mock(SubjectCredentialManager.class);
+        when(mockCredentialManager.getStoredCredentialsStream()).thenReturn(Stream.empty());
+        when(mockUser.credentialManager()).thenReturn(mockCredentialManager);
+        when(mockUser.isFederated()).thenReturn(true);
+
+        UserProvider userProvider = mock(UserProvider.class);
+        when(mockSession.users()).thenReturn(userProvider);
+        when(userProvider.getFederatedIdentitiesStream(mockRealm, mockUser))
+                .thenReturn(Stream.empty());
+
+        OLLoginAttemptBean bean = new OLLoginAttemptBean(mockUser, mockSession, mockRealm);
+
+        assertEquals("Rob Thomas", bean.getUserFullname());
+        assertFalse(bean.getNeedsPassword()); // no password credentials
+        assertFalse(bean.getHasSocialProviderAuth()); // federated identity present
+    }
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adds a new authenticator plugin to be used for a conditional in login flows
- Updates our login attempt bean to account for federated credentials

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Build the plugin and install in a Keycloak image. Test to see if login theme still works. Then try using the plugin as a conditional in a custom flow.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Credentials include:
- A local password
- A federated identity like LDAP
- An external identity like SAML or OAuth

This can be used as a conditional in a custom flow to trigger a password reset if there is no credential.
