### PR TITLE
Use the fullName attribute for login if present

### DIFF
--- a/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
+++ b/ol-keycloak/ol-spi/src/main/java/edu/mit/keycloak/forms/login/freemarker/models/OLLoginAttemptBean.java
@@ -17,7 +17,9 @@ public class OLLoginAttemptBean {
         this.needsPassword = true;
         this.hasSocialProviderAuth = false;
         if (user != null) {
-            if (user.getFirstName() != null && user.getLastName() != null) {
+            if (user.getFirstAttribute("fullName") != null) {
+                this.userFullname = user.getFirstAttribute("fullName");
+            } else if (user.getFirstName() != null && user.getLastName() != null) {
                 this.userFullname = user.getFirstName().concat(" ").concat(user.getLastName());
             }
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/8514

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updated the custom freemarker provider to use the fullname attribute if it is present.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Start to login, on the password page you should see your full name displayed instead of the default message and/or the concatenation of first + last name