### PR TITLE
Security: Disable npm scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
_This PR was generated automatically via a script._

This PR disables npm scripts by setting `ignore-scripts=true` in `.npmrc`.

## Why this change?

Disabling scripts improves security by:
- **Preventing malicious code execution**: Stops potentially harmful scripts from running during package installation
- **Supply chain security**: Reduces risk from compromised packages that could execute malicious scripts
- **Controlled execution**: Allows manual review and execution of necessary scripts only when needed

## What changed?

- Added `ignore-scripts=true` to `.npmrc`

## Impact

- Some packages may require manual script execution if they depend on install hooks
- Improved security posture against supply chain attacks
- No functional changes to core application code

This is a security best practice recommended for production applications to prevent potential malicious code execution during package installation.