### PR TITLE
fix(security): move the base image to Keycloak 26.7.1 to pick up 12 CVE fixes

### DIFF
--- a/Dockerfile.hosted
+++ b/Dockerfile.hosted
@@ -1,6 +1,6 @@
 # Build with something like:
 #  docker build -f ./Dockerfile.hosted --build-arg $(cat .keycloak_upstream_tag) --platform=linux/amd64 .
-FROM quay.io/keycloak/keycloak:26.7@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
+FROM quay.io/keycloak/keycloak:26.7@sha256:f1f1f01e472c8a78df40d8f2a49a925274eda4d3d80d5f6edbb5c880ee3c01c6
 
 # COPY ol-keycloak/ol-spi/ /opt/keycloak/providers/
 COPY plugins/*.jar /opt/keycloak/providers/

--- a/ol-keycloak/ol-spi/pom.xml
+++ b/ol-keycloak/ol-spi/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <keycloak.version>26.7.0</keycloak.version>
+        <keycloak.version>26.7.1</keycloak.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <freemarker.version>2.3.34</freemarker.version>


### PR DESCRIPTION
## What are the relevant tickets?

Surfaced during a dependency-update sweep of ol-infrastructure (mitodl/ol-infrastructure#5331 is the related, currently-blocked bump).

## Description (What does it do?)

Moves the `Dockerfile.hosted` base image from Keycloak **26.7.0** to **26.7.1**, and moves `ol-spi`'s compile-time `keycloak.version` to match.

The FROM digest was pinned at `0f198be`, which is 26.7.0 — specifically the `26.7.0-1` rebuild — not 26.7.1. The tag portion reads `:26.7`, which *now* floats to 26.7.1, so the line looks current at a glance, but the digest is what actually resolves. The image we ship has been running 26.7.0.

Digest map from quay.io, for the record:

| Digest | Tags | Published |
|---|---|---|
| `2eb3cd31…` | `26.7.0-0` | 2026-07-09 |
| `0f198be2…` | `26.7.0`, `26.7.0-1` | 2026-07-23 ← previous pin |
| `f1f1f01e…` | `26.7.1`, `26.7.1-0`, `26.7`, `latest` | 2026-08-05 ← this PR |

**26.7.1 is a security release fixing 12 CVEs**, including:

- CVE-2026-9793 — JWE request object bypasses `requestObjectSignatureAlg` enforcement
- CVE-2026-4629 — privilege escalation via hardcoded role mapper injection in `manage-clients`
- CVE-2026-15573 — authorization bypass via unnormalized URI matching in pathmatcher
- CVE-2026-15572 — DCR protocol mapper type-swap policy bypass allowing privilege escalation
- CVE-2026-16442 / CVE-2026-16443 — SAML idp-initiated broker login bypasses link-only restriction; SAML broker metadata import disables response signature validation
- CVE-2026-16071 — LDAP entry-dn user search bypasses configured users-dn boundary
- plus 5 more (FGAP bypasses, unbounded metric cardinality, DCR role forgery)

Renovate did not make this jump on its own: the shared mitodl config sets `minimumReleaseAge: 14 days`, and 26.7.1 was published 5 days ago. The `26.7.0-1` rebuild it did pick (#287) was 18 days old and cleared the soak. Taking a security fix ahead of that gate is the intended exception.

### Why the pom moves too

Only the Dockerfile digest changes what actually runs. But leaving `ol-spi` compiled against 26.7.0 while the server is 26.7.1 makes the two silently disagree, and the pom is where the next person looks to answer "what version are we on". Building against 26.7.1 also acts as a compile-time check that nothing `ol-spi` depends on moved.

### What this deliberately does not touch

`KEYCLOAK_VERSION` in ol-infrastructure stays at 26.7.0. That constant drives the CAS SPI resource's exact `tag_filter`, and [jacekkow/keycloak-protocol-cas](https://github.com/jacekkow/keycloak-protocol-cas) has no 26.7.1 tag yet — bumping it would stall the image build. Since the server version comes solely from this FROM digest, the CVE fixes land without waiting on that upstream tag.

## How can this be tested?

Already verified locally:

- `mvn clean test` against `keycloak.version=26.7.1` — **BUILD SUCCESS**, 9/9 tests pass (`OLLoginAttemptBeanTest`, `OlFreeMarkerLoginFormsProviderTest`, `OLSettingsBeanTest`)
- New digest confirmed to resolve and to match quay's `26.7.1` tag exactly, via both the quay API and `docker buildx imagetools inspect`
- `pre-commit run` on both changed files — all hooks pass

After the pipeline rebuilds and the new image digest reaches an environment:

- **Smoke-test CAS login.** This layers the CAS plugin jar built for 26.7.0 onto a 26.7.1 base. That is normally fine across a patch release, but it is the one combination this change newly creates.
- Confirm normal OIDC login through the customized `ol-freemarker` login theme.

## Additional Notes

Unrelated but noticed while here: the build comment at the top of `Dockerfile.hosted` references `.keycloak_upstream_tag`, which no longer exists in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzJSEBo5qNkeP62HupxRLw